### PR TITLE
fix: handle ddgs installed via uv tool

### DIFF
--- a/extensions/search-hub.ts
+++ b/extensions/search-hub.ts
@@ -310,7 +310,31 @@ async function searchDuckDuckGo(
 
 	const pyScript = `
 import json, sys
-from ddgs import DDGS
+try:
+    from ddgs import DDGS
+except ImportError:
+    # ddgs may be installed as a uv tool — find it and add to sys.path
+    import subprocess
+    try:
+        ddgs_bin = subprocess.check_output(["which", "ddgs"], text=True, stderr=subprocess.DEVNULL).strip()
+        if ddgs_bin:
+            import pathlib
+            # Follow symlinks to resolve to the uv tool dir
+            resolved = pathlib.Path(ddgs_bin).resolve()
+            tool_dir = resolved.parent.parent  # .../uv/tools/ddgs
+            sp_base = tool_dir / "lib"
+            found = False
+            for py_ver_dir in sorted(sp_base.iterdir(), reverse=True):
+                sp = py_ver_dir / "site-packages"
+                if sp.is_dir():
+                    sys.path.insert(0, str(sp))
+                    found = True
+                    break
+            if not found:
+                sys.exit(1)
+    except Exception:
+        sys.exit(1)
+    from ddgs import DDGS
 results = []
 with DDGS() as ddgs:
     for i, r in enumerate(ddgs.text(${JSON.stringify(query)}, max_results=${numResults})):


### PR DESCRIPTION
## Problem

When `ddgs` is installed via `uv tool install`, the isolated uv tool environment is not on `sys.path`, causing `ModuleNotFoundError: No module named 'ddgs'` when the DuckDuckGo search backend is invoked.

## Fix

Wrap the `from ddgs import DDGS` import in a try/except block. On `ImportError`, resolve the correct `site-packages` path by:
1. Running `which ddgs` to find the binary
2. Following symlinks to resolve to the uv tool directory
3. Locating the `lib/<python-version>/site-packages` path
4. Injecting it into `sys.path`

This is a single change to `extensions/search-hub.ts` (originally from the `pi-search-multi` codebase under its former name).

## Testing

- Works with standard pip-installed `ddgs` (import succeeds on first try)
- Works with `uv tool install ddgs` (fallback path resolution works)
- Gracefully exits with code 1 if neither mechanism finds the module