### PR TITLE
fix: robust ddgs uv tool path resolution

### DIFF
--- a/extensions/search-hub.ts
+++ b/extensions/search-hub.ts
@@ -310,7 +310,31 @@ async function searchDuckDuckGo(
 
 	const pyScript = `
 import json, sys
-from ddgs import DDGS
+try:
+    from ddgs import DDGS
+except ImportError:
+    # ddgs may be installed as a uv tool — find it and add to sys.path
+    import subprocess, pathlib
+    try:
+        ddgs_bin = subprocess.check_output(["which", "ddgs"], text=True, stderr=subprocess.DEVNULL).strip()
+        if ddgs_bin:
+            # Walk up from the binary until we find site-packages — no hardcoded depth assumption
+            ddgs_path = pathlib.Path(ddgs_bin).resolve()
+            found = False
+            for parent in [ddgs_path, *ddgs_path.parents]:
+                for py_ver_dir in sorted((parent / "lib").iterdir(), reverse=True):
+                    sp = py_ver_dir / "site-packages"
+                    if sp.is_dir():
+                        sys.path.insert(0, str(sp))
+                        found = True
+                        break
+                if found:
+                    break
+            if not found:
+                sys.exit(1)
+    except Exception:
+        sys.exit(1)
+    from ddgs import DDGS
 results = []
 with DDGS() as ddgs:
     for i, r in enumerate(ddgs.text(${JSON.stringify(query)}, max_results=${numResults})):


### PR DESCRIPTION
Robustify the ddgs uv tool path resolution from the original PR #7 by halcyon:

- Walk up the directory tree from the binary until site-packages is found — no hardcoded depth assumption
- Handles non-standard UV_TOOL_DIR, shell aliases, and wrapper scripts that break parent.parent anchoring

Thanks @halcyon for identifying the original fix!