### PR TITLE
feat: add combine config option to force combine mode from search.json

### DIFF
--- a/extensions/search-hub.ts
+++ b/extensions/search-hub.ts
@@ -64,6 +64,7 @@ interface BackendConfig {
 
 interface SearchConfig {
 	defaultBackend?: string;
+	combine?: boolean;
 	selectionStrategy?: "sequential" | "random" | "round-robin" | "best-latency";
 	backends?: {
 		duckduckgo?: BackendConfig;
@@ -1309,6 +1310,9 @@ export default function (pi: ExtensionAPI) {
 			const numResults = Math.max(1, Math.min(params.numResults ?? 10, 20));
 			const requestedBackend = params.backend || "auto";
 			const combine = params.combine ?? false;
+			// If config has combine:true, force combine mode regardless of LLM choice
+			const forceCombine = config.combine === true;
+			const effectiveCombine = forceCombine || combine;
 
 			if (requestedBackend !== "auto") {
 				// Specific backend requested — try it directly
@@ -1320,7 +1324,7 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			// Auto mode
-			if (combine) {
+			if (effectiveCombine) {
 				// Combine mode: query all enabled backends in parallel
 				const resultsPerBackend = await Promise.all(
 					activeBackends.map(async (backend) => {


### PR DESCRIPTION
## Description

First of all — thank you for building pi-search-hub. It is one of the most useful pi extensions and the 12-backend architecture with RRF combine mode is genuinely well-designed.

### Motivation

The `combine` mode (combine: true) queries all enabled backends in parallel and merges results via Reciprocal Rank Fusion, producing richer and more diverse search results. However, in `auto` mode the LLM decides whether to pass `combine: true` or not — and in practice models tend to omit it.

The result is that the extension falls back to trying backends sequentially and returning results from the **first one that works** — typically DuckDuckGo (free, fast, no key). This has two downsides:

1. **Quota burn** — DuckDuckGo gets every query instead of being load-balanced across all backends, exhausting rate limits faster.
2. **Backend-biased results** — different search engines index differently. DuckDuckGo alone may miss results that Serper, Tavily, Exa, or Marginalia would find.

This PR adds a `combine` config option so the user can **force combine mode at the config level**, independent of what the LLM decides to pass as a tool parameter.

### Change

```ts
interface SearchConfig {
    defaultBackend?: string;
    combine?: boolean;            // ← new
    selectionStrategy?: "sequential" | "random" | "round-robin" | "best-latency";
    ...
}
```

When `"combine": true` is set in `search.json`, the extension always runs in combine mode regardless of the LLM's tool call. When unset or `false`, the original behavior is preserved (LLM decides).

### Usage

```json
{
  "combine": true,
  "defaultBackend": "auto",
  "backends": { ... }
}
```
