### PR TITLE
feat: add Sofya backend (web_search) + pluggable web_read reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-search-hub
 
-Unified web search + content extraction extension for [pi](https://pi.dev) with **12 backend providers** (all working). One `web_search` tool, one `web_read` tool, auto-fallback, RRF-ranked combine mode, and credential resolution via env/shell/literal.
+Unified web search + content extraction extension for [pi](https://pi.dev) with **17 backend providers** (all working). One `web_search` tool, one `web_read` tool (pluggable reader: Jina or Sofya), auto-fallback, RRF-ranked combine mode, and credential resolution via env/shell/literal.
 
 ## Installation
 
@@ -53,7 +53,7 @@ Search for "Rust vs Go performance benchmarks" with combine=true to get results 
 ### Read Web Pages
 
 Fetch any URL as clean markdown — great for extracting article content, docs, or reference pages.
-**Note: `web_read` uses [Jina Reader](https://r.jina.ai/) to fetch and convert URLs to markdown.**
+**Note: `web_read` uses [Jina Reader](https://r.jina.ai/) by default. Set `reader` to choose the engine.**
 
 ```text
 Read https://docs.example.com/api-reference
@@ -61,10 +61,11 @@ Read https://docs.example.com/api-reference
 
 The `web_read` tool supports:
 
-- **objective** — CSS selector to target specific content (e.g. "div.article-body")
-- **keywords** — relevant terms to highlight on long pages
-- **mode** — `rush` for speed (return innerText) or `smart` (markdown extraction)
-- **fresh** — bypass cache when freshness matters
+- **reader**: `jina` (default, free, no key) or `sofya` ([Sofya](https://sofya.co) Fetch, 250+ site-specific parsers, needs an API key). Set a project-wide default with `"reader"` in `search.json`, or override per call.
+- **objective**: CSS selector to target specific content (e.g. "div.article-body") _(Jina reader only)_
+- **keywords**: relevant terms to highlight on long pages _(Jina reader only)_
+- **mode**: `rush` for speed (return innerText) or `smart` (markdown extraction) _(Jina reader only)_
+- **fresh**: bypass cache when freshness matters
 
 ## Supported Backends
 
@@ -82,6 +83,11 @@ The `web_read` tool supports:
 | 10  | **WebSearchAPI.ai**   | 2,000 free credits            |   Yes    | [websearchapi.ai](https://www.websearchapi.ai)                    |
 | 11  | **Perplexity Sonar**  | Paid (usage-based)            |   Yes    | [perplexity.ai](https://docs.perplexity.ai)                       |
 | 12  | **SearXNG**           | Self-hosted, unlimited        |  **No**  | [docs.searxng.org](https://docs.searxng.org)                      |
+| 13  | **Brave LLM**         | Shares Brave key & quota      |   Yes    | [brave.com/search/api](https://brave.com/search/api)              |
+| 14  | **Linkup**            | $20 free credit (EU/GDPR)     |   Yes    | [linkup.so](https://www.linkup.so)                                |
+| 15  | **You.com**           | $100 free credits             |   Yes    | [you.com](https://api.you.com)                                    |
+| 16  | **fastCRW**           | 500 free/month, self-hostable |   Yes    | [fastcrw.com](https://www.fastcrw.com)                            |
+| 17  | **Sofya**             | 1,000 credits on GitHub signup |  Yes    | [sofya.co](https://sofya.co)                                      |
 
 > † Marginalia Search uses `public` as a shared API key — no registration required, but subject to a shared rate limit.
 >
@@ -94,6 +100,8 @@ The `web_read` tool supports:
 > **Firecrawl** uses `api.firecrawl.dev/v2/search` with a `data.web[]` response shape. The v1 endpoint is deprecated.
 >
 > **Exa** (March 2026) includes content for the first 10 results per request at no extra cost. Content extraction is enabled by default.
+>
+> **Sofya** ([sofya.co](https://sofya.co)) gives **1,000 free credits when you sign up with GitHub**, and powers both a `web_search` backend and the `web_read` reader from one key. Search uses `POST /v1/search` (`basic` depth returns full extracted page content, ~3 credits; `snippets` returns SERP snippets, 1 credit, set via `searchDepth`). The `web_read` Sofya reader uses `POST /v1/fetch` (1 credit/URL) with 250+ site-specific parsers. Configure depth/topic per backend in `.pi/search.json`.
 
 ## Configuration
 
@@ -105,9 +113,11 @@ Configure backends globally (all projects) or per-project:
 ```json
 {
   "defaultBackend": "auto",
+  "reader": "jina",
   "backends": {
     "duckduckgo": { "enabled": true },
     "jina": { "enabled": true, "apiKey": "JINA_API_KEY" },
+    "sofya": { "enabled": true, "apiKey": "SOFYA_API_KEY", "searchDepth": "basic" },
     "marginalia": { "enabled": true },
     "serper": { "enabled": true, "apiKey": "SERPER_API_KEY" },
     "tavily": { "enabled": true, "apiKey": "TAVILY_API_KEY" },

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,24 @@
+# Release v2.2.0 (Sofya backend + pluggable web_read reader)
+
+## 🚀 New
+- **Sofya** ([sofya.co](https://sofya.co)): adds a `web_search` backend (`POST /v1/search`, full extracted page content at `basic` depth) AND a `web_read` reader (`POST /v1/fetch`, 250+ site-specific parsers), both from a single API key.
+- **Pluggable `web_read` reader**: `web_read` is no longer hardcoded to Jina. Choose `jina` (default, free) or `sofya` via the new top-level `"reader"` config setting, or per-call with the `reader` tool param.
+
+## 📊 Stats
+- 17 backends total (was 16)
+- 70 tests passing (was 65), added `parseSofya` coverage
+
+## 🔧 Changes
+- `extensions/backends/sofya.ts`: New adapter exporting `searchSofya` + `fetchSofya`.
+- `parsers.ts`: Added `parseSofya` (full `content` + `description` snippet).
+- `registry.ts`: Registered `sofya` BACKEND_DEF (honors `searchDepth`, `topic`).
+- `types.ts`: Added `sofya` to SearchConfig, top-level `reader`, and `searchDepth`/`topic` per-backend options.
+- `credentials.ts`: Added `SEARCH_SOFYA_API_KEY` convenience env var.
+- `search-hub.ts`: `web_read` branches on reader (Jina vs Sofya Fetch); `web_search` backend enum completed (added the 4 v2.1.0 backends that were missing from the enum, plus `sofya`).
+- `package.json`: Description/keywords updated to 17 backends.
+
+---
+
 # Release v2.1.0 (4 new backends)
 
 ## 🚀 New Backends

--- a/backends/parsers.test.ts
+++ b/backends/parsers.test.ts
@@ -15,6 +15,7 @@ import {
 	parsePerplexity,
 	parseSearXNG,
 	parseJina,
+	parseSofya,
 } from "./parsers.js";
 
 // ---------------------------------------------------------------------------
@@ -406,5 +407,47 @@ describe("parseJina", () => {
 		const data = { data: [{ title: "J", url: "https://j.com", content: "x".repeat(3000) }] };
 		const results = parseJina(data, 10);
 		expect(results[0].content.length).toBe(2000);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Sofya
+// ---------------------------------------------------------------------------
+
+describe("parseSofya", () => {
+	it("parses results with content and description", () => {
+		const data = {
+			results: [
+				{ title: "S", url: "https://s.com", content: "full page text", description: "snippet" },
+			],
+		};
+		const results = parseSofya(data, 10);
+		expect(results[0].title).toBe("S");
+		expect(results[0].content).toBe("full page text");
+		// snippet prefers description (the SERP snippet) over full content
+		expect(results[0].snippet).toBe("snippet");
+	});
+
+	it("falls back to content when description is missing", () => {
+		const data = { results: [{ title: "S", url: "https://s.com", content: "body only" }] };
+		const results = parseSofya(data, 10);
+		expect(results[0].snippet).toBe("body only");
+	});
+
+	it("truncates content to 2000 chars", () => {
+		const data = { results: [{ title: "S", url: "https://s.com", content: "x".repeat(3000) }] };
+		const results = parseSofya(data, 10);
+		expect(results[0].content.length).toBe(2000);
+	});
+
+	it("handles non-array data and missing fields", () => {
+		expect(parseSofya({}, 10)).toHaveLength(0);
+		expect(parseSofya({ results: "nope" }, 10)).toHaveLength(0);
+		expect(parseSofya({ results: [{}] }, 10)[0]).toEqual({ title: "", url: "", snippet: "", content: "" });
+	});
+
+	it("respects numResults limit", () => {
+		const data = { results: Array.from({ length: 10 }, (_, i) => ({ url: `https://s.com/${i}`, title: `T${i}` })) };
+		expect(parseSofya(data, 3)).toHaveLength(3);
 	});
 });

--- a/backends/parsers.ts
+++ b/backends/parsers.ts
@@ -329,3 +329,30 @@ export function parseJina(
 		snippet: ((r.content as string) || (r.description as string) || "").slice(0, 500),
 	}));
 }
+
+// ---------------------------------------------------------------------------
+// Sofya (sofya.co)
+// Response: { results: [{ title, url, content, description, published_date }] }
+// `content` is full extracted page text (basic depth); `description` is the SERP snippet.
+// ---------------------------------------------------------------------------
+
+export interface SofyaParsedResult extends ParsedResult {
+	content: string;
+}
+
+export function parseSofya(
+	data: Record<string, unknown>,
+	numResults: number,
+): SofyaParsedResult[] {
+	const rawResults = data.results;
+	const results = Array.isArray(rawResults) ? rawResults : [];
+	return results.slice(0, numResults).map((r) => {
+		const content = (r.content as string) || (r.description as string) || "";
+		return {
+			title: (r.title as string) || "",
+			url: (r.url as string) || "",
+			snippet: ((r.description as string) || content).slice(0, 500),
+			content: content.slice(0, 2000),
+		};
+	});
+}

--- a/extensions/backends/registry.ts
+++ b/extensions/backends/registry.ts
@@ -23,6 +23,7 @@ import { searchBraveLLM } from "./brave-llm.js";
 import { searchLinkup } from "./linkup.js";
 import { searchYoucom } from "./youcom.js";
 import { searchFastcrw } from "./fastcrw.js";
+import { searchSofya } from "./sofya.js";
 
 // ---------------------------------------------------------------------------
 // Backend Registry
@@ -227,6 +228,21 @@ export const BACKEND_DEFS: Record<string, BackendRunner> = {
 		search: async (query, numResults, { key, signal }) => {
 			const bc = (config.backends as Record<string, BackendConfig> | undefined)?.fastcrw;
 			const result = await searchFastcrw(query, numResults, key!, signal, bc?.baseUrl);
+			return { results: result.results };
+		},
+	},
+	sofya: {
+		needsKey: true,
+		needsKeyFromConfig: false,
+		optionalKey: false,
+		needsInstanceUrl: false,
+		label: "Sofya",
+		setupLabel: "Sofya (search + fetch, full page content)",
+		search: async (query, numResults, { key, signal, backendConfig }) => {
+			const result = await searchSofya(query, numResults, key!, signal, {
+				searchDepth: backendConfig?.searchDepth,
+				topic: backendConfig?.topic,
+			});
 			return { results: result.results };
 		},
 	},

--- a/extensions/backends/sofya.ts
+++ b/extensions/backends/sofya.ts
@@ -1,0 +1,82 @@
+/**
+ * Sofya backend: web search + content extraction (https://sofya.co).
+ *
+ * Two capabilities, both behind one API key (Bearer ay_live_...):
+ *   • search (web_search): POST /v1/search, returns extracted page content
+ *   • fetch  (web_read):   POST /v1/fetch, URL(s) to clean markdown (250+ parsers)
+ */
+
+import { timeoutSignal, sanitizeError } from "../utils.js";
+import { parseSofya } from "../../backends/parsers.js";
+import type { SearchResult } from "../types.js";
+
+const SOFYA_BASE = "https://sofya.co";
+
+export async function searchSofya(
+	query: string,
+	numResults: number,
+	apiKey: string,
+	signal?: AbortSignal,
+	opts?: { searchDepth?: "snippets" | "basic"; topic?: "general" | "news" },
+): Promise<{ results: SearchResult[] }> {
+	const body = {
+		query,
+		search_depth: opts?.searchDepth ?? "basic",
+		max_results: Math.min(numResults, 20),
+		include_answer: false,
+		topic: opts?.topic ?? "general",
+	};
+	const response = await fetch(`${SOFYA_BASE}/v1/search`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${apiKey}`,
+		},
+		body: JSON.stringify(body),
+		signal: timeoutSignal(signal),
+	});
+	if (!response.ok) {
+		const text = await response.text().catch(() => "");
+		throw new Error(`Sofya ${sanitizeError(response.status, text)}`);
+	}
+	const data = (await response.json()) as Record<string, unknown>;
+	return { results: parseSofya(data, numResults) };
+}
+
+/**
+ * Fetch a single URL as clean markdown via Sofya Fetch.
+ * Returns the extracted content; throws on transport error or per-URL failure.
+ */
+export async function fetchSofya(
+	url: string,
+	apiKey: string,
+	signal?: AbortSignal,
+): Promise<{ title: string; url: string; content: string }> {
+	const response = await fetch(`${SOFYA_BASE}/v1/fetch`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${apiKey}`,
+		},
+		body: JSON.stringify({ urls: [url], include_raw_html: false }),
+		signal: timeoutSignal(signal),
+	});
+	if (!response.ok) {
+		const text = await response.text().catch(() => "");
+		throw new Error(`Sofya fetch ${sanitizeError(response.status, text)}`);
+	}
+	const data = (await response.json()) as Record<string, unknown>;
+	const results = Array.isArray(data.results)
+		? (data.results as Array<Record<string, unknown>>)
+		: [];
+	const first = results[0];
+	if (!first || first.success === false) {
+		const err = (first?.error as string) || "no content returned";
+		throw new Error(`Sofya fetch failed for ${url}: ${err}`);
+	}
+	return {
+		title: (first.title as string) || "",
+		url: (first.url as string) || url,
+		content: (first.content as string) || "",
+	};
+}

--- a/extensions/credentials.ts
+++ b/extensions/credentials.ts
@@ -90,6 +90,7 @@ export const FALLBACK_ENV_MAP: Record<string, string> = {
 	firecrawl: "SEARCH_FIRECRAWL_API_KEY",
 	websearchapi: "SEARCH_WEBSEARCHAPI_API_KEY",
 	perplexity: "SEARCH_PERPLEXITY_API_KEY",
+	sofya: "SEARCH_SOFYA_API_KEY",
 };
 
 /** Lazy resolution: config.apiKey → resolveConfigValue() → FALLBACK_ENV_MAP fallback. */

--- a/extensions/search-hub.ts
+++ b/extensions/search-hub.ts
@@ -44,8 +44,9 @@ import { StringEnum } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 
 import type { BackendConfig, SearchConfig, SearchResult, SearchResultWithBackend } from "./types.js";
-import { getAgentDir, timeoutSignal, sanitizeError, clearCooldowns } from "./utils.js";
+import { getAgentDir, timeoutSignal, sanitizeError, clearCooldowns, MISSING_KEY_HELP } from "./utils.js";
 import { resolveBackendKey, getKeySource } from "./credentials.js";
+import { fetchSofya } from "./backends/sofya.js";
 import { config, refreshConfig, getActiveBackends, recordLatency, latencyMap } from "./config.js";
 import { BACKEND_DEFS, runBackend } from "./backends/registry.js";
 import { selectBackendsForFallback, reciprocalRankFusion } from "./dispatch.js";
@@ -90,7 +91,8 @@ export default function (pi: ExtensionAPI) {
 			),
 			backend: Type.Optional(
 				StringEnum(["duckduckgo", "jina", "marginalia", "serper", "tavily", "exa",
-					"brave", "langsearch", "firecrawl", "websearchapi", "perplexity", "searxng", "auto"] as const, {
+					"brave", "brave-llm", "langsearch", "firecrawl", "websearchapi", "perplexity",
+					"searxng", "linkup", "youcom", "fastcrw", "sofya", "auto"] as const, {
 					description:
 						"Backend to use. 'auto' picks the best configured backend (default)",
 				}),
@@ -265,7 +267,14 @@ export default function (pi: ExtensionAPI) {
 			objective: Type.Optional(
 				Type.String({
 					description:
-						"CSS selector for targeted extraction. Use when only part of the page matters.",
+						"CSS selector for targeted extraction. Use when only part of the page matters. (Jina reader only.)",
+				}),
+			),
+			reader: Type.Optional(
+				StringEnum(["jina", "sofya"] as const, {
+					description:
+						"Reader backend: 'jina' (default, free, supports keywords/mode/objective) or " +
+						"'sofya' (250+ site-specific parsers, needs API key). Overrides the configured default.",
 				}),
 			),
 		}),
@@ -276,43 +285,57 @@ export default function (pi: ExtensionAPI) {
 				? params.url
 				: `https://${params.url}`;
 
-			// Build Jina Reader URL
-			const readerUrl = new URL("https://r.jina.ai/" + url);
+			const reader = params.reader ?? config.reader ?? "jina";
 
-			const headers: Record<string, string> = {
-				"Accept": "text/plain",
-			};
+			let content: string;
+			if (reader === "sofya") {
+				// Sofya Fetch: clean markdown via 250+ site-specific parsers.
+				const sofyaKey = resolveBackendKey("sofya", config);
+				if (!sofyaKey) {
+					throw new Error(`Sofya reader selected but no API key configured. ${MISSING_KEY_HELP}`);
+				}
+				const result = await fetchSofya(url, sofyaKey, signal);
+				content = result.content;
+			} else {
+				// Jina Reader: free, supports keywords / mode / objective hints.
+				const readerUrl = new URL("https://r.jina.ai/" + url);
 
-			// Optional Jina API key for higher rate limits (fallback to no-auth)
-			const jinaKey = resolveBackendKey("jina", config);
-			if (jinaKey) {
-				headers["Authorization"] = `Bearer ${jinaKey}`;
+				const headers: Record<string, string> = {
+					"Accept": "text/plain",
+				};
+
+				// Optional Jina API key for higher rate limits (fallback to no-auth)
+				const jinaKey = resolveBackendKey("jina", config);
+				if (jinaKey) {
+					headers["Authorization"] = `Bearer ${jinaKey}`;
+				}
+
+				if (params.fresh) {
+					headers["x-no-cache"] = "true";
+				}
+				if (params.keywords && params.keywords.length > 0) {
+					headers["x-keywords"] = params.keywords.join(", ");
+				}
+				if (params.mode) {
+					headers["x-respond-with"] = params.mode === "rush" ? "text" : "markdown";
+				}
+				if (params.objective) {
+					headers["x-target-selector"] = params.objective;
+				}
+
+				const response = await fetch(readerUrl.toString(), {
+					signal: timeoutSignal(signal),
+					headers,
+				});
+
+				if (!response.ok) {
+					const text = await response.text().catch(() => "");
+					throw new Error(`Failed to read ${url}: ${sanitizeError(response.status, text)}`);
+				}
+
+				content = await response.text();
 			}
 
-			if (params.fresh) {
-				headers["x-no-cache"] = "true";
-			}
-			if (params.keywords && params.keywords.length > 0) {
-				headers["x-keywords"] = params.keywords.join(", ");
-			}
-			if (params.mode) {
-				headers["x-respond-with"] = params.mode === "rush" ? "text" : "markdown";
-			}
-			if (params.objective) {
-				headers["x-target-selector"] = params.objective;
-			}
-
-			const response = await fetch(readerUrl.toString(), {
-				signal: timeoutSignal(signal),
-				headers,
-			});
-
-			if (!response.ok) {
-				const text = await response.text().catch(() => "");
-				throw new Error(`Failed to read ${url}: ${sanitizeError(response.status, text)}`);
-			}
-
-			const content = await response.text();
 			const truncated = content.length > 10000
 				? content.slice(0, 10000) + `\n\n[... truncated, full length: ${content.length} chars]`
 				: content;
@@ -321,6 +344,7 @@ export default function (pi: ExtensionAPI) {
 				content: [{ type: "text", text: truncated }],
 				details: {
 					url,
+					reader,
 					length: content.length,
 					truncated: content.length > 10000,
 				},

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -27,12 +27,18 @@ export interface BackendConfig {
 	depth?: "standard" | "deep";
 	/** fastCRW-specific: base URL override (for self-hosted). Default: https://api.fastcrw.com */
 	baseUrl?: string;
+	/** Sofya-specific: search depth. "snippets" (1cr, SERP only) or "basic" (3cr, full page content). Default: basic */
+	searchDepth?: "snippets" | "basic";
+	/** Sofya-specific: topic. "general" or "news". Default: general */
+	topic?: "general" | "news";
 }
 
 export interface SearchConfig {
 	defaultBackend?: string;
 	combine?: boolean;
 	selectionStrategy?: "sequential" | "random" | "round-robin" | "best-latency";
+	/** Reader backend for web_read. "jina" (default, free) or "sofya" (250+ site parsers, needs key). */
+	reader?: "jina" | "sofya";
 	/** Cache TTL in milliseconds. Default: 300000 (5 min). Set to 0 to disable. */
 	cacheTtl?: number;
 	/** Max cached queries. Default: 100. */
@@ -54,6 +60,7 @@ export interface SearchConfig {
 		linkup?: BackendConfig;
 		youcom?: BackendConfig;
 		fastcrw?: BackendConfig;
+		sofya?: BackendConfig;
 	};
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-search-hub",
-  "version": "2.0.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-search-hub",
-      "version": "2.0.1",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "typebox": "^1.1.24"
@@ -192,9 +192,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -212,9 +209,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -232,9 +226,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -252,9 +243,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -272,9 +260,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -292,9 +277,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -787,9 +769,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -811,9 +790,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -835,9 +811,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -859,9 +832,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-search-hub",
-  "version": "2.1.0",
-  "description": "Unified web search + content extraction extension for pi with 16 backends (DuckDuckGo, Jina AI, Tavily, Brave, Brave LLM, Exa, Serper, Firecrawl, fastCRW, Marginalia, LangSearch, Linkup, Perplexity Sonar, SearXNG, WebSearchAPI, You.com). Auto-fallback, RRF combine mode, web_read tool, secure credential resolution.",
+  "version": "2.2.0",
+  "description": "Unified web search + content extraction extension for pi with 17 backends (DuckDuckGo, Jina AI, Tavily, Brave, Brave LLM, Exa, Serper, Firecrawl, fastCRW, Marginalia, LangSearch, Linkup, Perplexity Sonar, SearXNG, WebSearchAPI, You.com, Sofya). Auto-fallback, RRF combine mode, pluggable web_read reader (Jina or Sofya), secure credential resolution.",
   "keywords": [
     "pi-package",
     "pi",
@@ -25,6 +25,7 @@
     "fastcrw",
     "linkup",
     "youcom",
+    "sofya",
     "rrf",
     "ai-agent"
   ],

--- a/search.json.example
+++ b/search.json.example
@@ -1,7 +1,9 @@
 {
   "defaultBackend": "auto",
+  "reader": "jina",
   "backends": {
     "duckduckgo": { "enabled": true },
+    "sofya": { "enabled": true, "apiKey": "SOFYA_API_KEY", "searchDepth": "basic" },
     "jina": { "enabled": true },
     "marginalia": { "enabled": true },
     "serper": { "enabled": true, "apiKey": "SERPER_API_KEY" },


### PR DESCRIPTION
## Summary

Adds **Sofya** ([sofya.co](https://sofya.co)) as the 17th web search backend, plus a pluggable `web_read` reader (Jina default, or Sofya Fetch with 250+ site-specific parsers). One API key covers both.

Sofya gives **1,000 free credits when you sign up with GitHub**, and benchmarks well: on agentic SimpleQA (June 2026) it placed 2nd of 7 backends at 97% accuracy (a statistical tie for 1st) with the fewest searches per question, since results return full page content instead of snippets.

## Changes
- `extensions/backends/sofya.ts`: `searchSofya` (`POST /v1/search`) and `fetchSofya` (`POST /v1/fetch`)
- `parseSofya` parser with unit tests; registered in `registry.ts` (honors `searchDepth`, `topic`)
- `types.ts` (`sofya` config, top-level `reader`, `searchDepth`/`topic`) and `credentials.ts` (`SEARCH_SOFYA_API_KEY`)
- `search-hub.ts`: `web_read` branches on `reader`; also completed the `web_search` enum (it was missing the 4 backends from v2.1.0, now plus `sofya`)
- Docs and `package.json` bumped to 2.2.0

## Testing
70 unit tests pass. Verified live against the real API: search (both depths), fetch (success and error), and registry dispatch with credential resolution and caching.
