### PR TITLE
Add OpenAI Codex search backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,12 +208,25 @@ Or use the interactive setup:
 
 ### Combine Mode (`combine=true`)
 
+By default, combine mode uses `combineMode: "all"`:
+
 1. Queries **ALL** enabled backends in parallel
 2. Each backend receives `numResults / numBackends` as a target
 3. Results are merged using **Reciprocal Rank Fusion** (RRF) — position-based scoring that works across incompatible ranking systems
 4. Each result shows its source backend (e.g., `*Source: Tavily*`)
 5. URL dedup prefers the result with the richest content (content > snippet)
 6. Backend statistics are displayed (which succeeded, result counts, errors)
+
+For lower fan-out with multiple sources, set targeted combine in `search.json`:
+
+```json
+{
+  "combine": true,
+  "combineMode": "targeted"
+}
+```
+
+Targeted combine orders active backends using the configured selection strategy, then keeps querying only as many backends as needed to collect up to 3 usable backends. A backend is usable when it returns non-empty results. If fewer than 3 usable backends are available after all active backends are tried, targeted combine returns whatever usable results were found; if none are usable, it reports the collected failures/empty responses.
 
 ### RRF Scoring
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-search-hub
 
-Unified web search + content extraction extension for [pi](https://pi.dev) with **18 backend providers** (all working). One `web_search` tool, one `web_read` tool (Jina or Sofya reader), auto-fallback, RRF-ranked combine mode, and credential resolution via env/shell/literal.
+Unified web search + content extraction extension for [pi](https://pi.dev) with **19 backend providers** (all working). One `web_search` tool, one `web_read` tool (Jina or Sofya reader), auto-fallback, RRF-ranked combine mode, and credential resolution via env/shell/literal.
 
 ## Installation
 
@@ -79,6 +79,7 @@ The `web_read` tool supports:
 | 7   | **Firecrawl**         | 500 free credits              |   Yes    | [firecrawl.dev](https://www.firecrawl.dev)                        |
 | 8   | **Exa**               | 1,000 free queries/month      |   Yes    | [exa.ai](https://dashboard.exa.ai/api-keys)                       |
 | 8.1 | **Exa MCP**           | Unlimited (rate-limited)      |  **No**  | [mcp.exa.ai](https://mcp.exa.ai)                                 |
+| 8.2 | **OpenAI Codex**      | Included with Pi login        |  **No**  | Enable backend, then run `/login` in Pi and select OpenAI Codex  |
 | 9   | **LangSearch**        | Genuinely free, no CC         |   Yes    | [langsearch.com](https://langsearch.com)                          |
 | 10  | **WebSearchAPI.ai**   | 2,000 free credits            |   Yes    | [websearchapi.ai](https://www.websearchapi.ai)                    |
 | 11  | **Perplexity Sonar**  | Paid (usage-based)            |   Yes    | [perplexity.ai](https://docs.perplexity.ai)                       |
@@ -94,6 +95,8 @@ The `web_read` tool supports:
 > † Marginalia Search uses `public` as a shared API key — no registration required, but subject to a shared rate limit.
 >
 > **Jina AI:** Search (`s.jina.ai`) requires a free API key from [jina.ai](https://jina.ai). Content extraction via `web_read` uses Jina Reader (`r.jina.ai`) which is **free and needs no API key**.
+>
+> **OpenAI Codex** uses Pi-managed authentication. Enable `openai-codex` in `search.json`, then run `/login` in Pi and select OpenAI Codex. No `apiKey` is required in `search.json`. You can optionally set `model` (default: `gpt-5.4-mini`).
 >
 > **Perplexity Sonar** supports multiple model variants. Set `model` in your Perplexity backend config to choose: `sonar` (default, fast), `sonar-pro` (higher quality), `sonar-deep-research` (multi-step reasoning), or `sonar-reasoning` (DeepSeek R1-based).
 >
@@ -124,6 +127,7 @@ Configure backends globally (all projects) or per-project:
     "tavily": { "enabled": true, "apiKey": "TAVILY_API_KEY" },
     "brave": { "enabled": true, "apiKey": "BRAVE_API_KEY" },
     "exa": { "enabled": true, "apiKey": "EXA_API_KEY" },
+    "openai-codex": { "enabled": true, "model": "gpt-5.4-mini" },
     "firecrawl": { "enabled": true, "apiKey": "FIRECRAWL_API_KEY" },
     "langsearch": { "enabled": true, "apiKey": "LANGSEARCH_API_KEY" },
     "websearchapi": { "enabled": true, "apiKey": "WEBSEARCHAPI_API_KEY" },
@@ -175,6 +179,8 @@ export SEARCH_EXA_API_KEY="sk-..."
 
 **To rotate a shell-command key:** Update the secret in your password manager, then trigger a config reload (edit the config file, or wait 10s for automatic refresh).
 
+OpenAI Codex does not use `apiKey` from `search.json`. Enable the backend in config, then run `/login` in Pi and select OpenAI Codex.
+
 Or use the interactive setup:
 
 ```
@@ -225,8 +231,8 @@ RRF assigns each result a score of `Σ(1 / (60 + rank_i))` across all backends t
 ## Testing
 
 ```bash
-# Run unit tests for backend parsers
-npx vitest run backends/parsers.test.ts
+# Run unit tests for backend parsers and OpenAI Codex helpers
+npx vitest run backends/parsers.test.ts extensions/openai-codex.test.ts
 
 # Quick test Jina AI (with your free API key)
 curl -s -H "Authorization: Bearer $JINA_API_KEY" "https://s.jina.ai/?q=test&format=json" | jq .

--- a/extensions/backends/openai-codex.ts
+++ b/extensions/backends/openai-codex.ts
@@ -1,0 +1,260 @@
+import { AuthStorage } from "@earendil-works/pi-coding-agent";
+import {
+	getModel,
+	streamOpenAICodexResponses,
+	type Context,
+	type Model,
+} from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+
+import type { BackendConfig, SearchResult } from "../types.js";
+
+const DEFAULT_MODEL_ID = "gpt-5.4-mini";
+const DEFAULT_SEARCH_CONTEXT_SIZE = "low";
+const MAX_TOOL_RESULTS = 20;
+const MAX_TITLE_LENGTH = 200;
+const MAX_SNIPPET_LENGTH = 1000;
+const MAX_CONTENT_LENGTH = 4000;
+
+const SUBMIT_SEARCH_RESULTS_TOOL = {
+	name: "submit_search_results",
+	description: "Submit structured search results based on the available source evidence.",
+	parameters: Type.Object({
+		results: Type.Array(
+			Type.Object({
+				title: Type.String({
+					description: "Page title or clearest source title for the URL.",
+				}),
+				url: Type.String({
+					description: "Canonical http/https URL for the result.",
+				}),
+				snippet: Type.String({
+					description:
+						"One concise sentence with the most query-relevant facts, claims, or details from the available source evidence. Do not write an opinion about usefulness.",
+				}),
+				content: Type.Optional(Type.String({
+					description:
+						"Optional. A longer query-relevant summary of the available source evidence with additional concrete details beyond the snippet. Omit if evidence is thin or repetitive. Do not invent or present unsupported text as source content.",
+				})),
+			}),
+			{ maxItems: MAX_TOOL_RESULTS },
+		),
+	}),
+} as const;
+
+export async function searchOpenAICodex(
+	query: string,
+	numResults: number,
+	signal?: AbortSignal,
+	backendConfig?: BackendConfig,
+): Promise<{ results: SearchResult[] }> {
+	if (signal?.aborted) {
+		throw new Error("OpenAI Codex search cancelled");
+	}
+
+	const apiKey = await resolveOpenAICodexAccessToken();
+	const modelId = backendConfig?.model?.trim() || DEFAULT_MODEL_ID;
+	const model = getModel("openai-codex", modelId) as Model<"openai-codex-responses"> | undefined;
+	if (!model) {
+		throw new Error(`OpenAI Codex model not found: ${modelId}`);
+	}
+
+	const context: Context = {
+		systemPrompt: buildSystemPrompt(numResults),
+		messages: [
+			{
+				role: "user",
+				content: query,
+				timestamp: Date.now(),
+			},
+		],
+		tools: [SUBMIT_SEARCH_RESULTS_TOOL],
+	};
+
+	const message = await streamOpenAICodexResponses(model, context, {
+		apiKey,
+		signal,
+		transport: "sse",
+		reasoningEffort: "minimal",
+		textVerbosity: "low",
+		onPayload: (payload) => injectCodexSearchPayload(payload),
+	}).result();
+
+	if (message.stopReason === "error") {
+		throw new Error(message.errorMessage || "OpenAI Codex search failed");
+	}
+	if (message.stopReason === "aborted") {
+		throw new Error("OpenAI Codex search cancelled");
+	}
+
+	const submitCall = message.content.find(
+		(block) => block.type === "toolCall" && block.name === "submit_search_results",
+	);
+	if (!submitCall || submitCall.type !== "toolCall") {
+		throw new Error("OpenAI Codex search did not submit structured results");
+	}
+
+	const results = normalizeSubmitSearchResults(submitCall.arguments, numResults);
+	if (results.length === 0) {
+		throw new Error("OpenAI Codex search returned no valid URL results");
+	}
+
+	return { results };
+}
+
+async function resolveOpenAICodexAccessToken(): Promise<string> {
+	const authStorage = AuthStorage.create();
+	const apiKey = await authStorage.getApiKey("openai-codex", {
+		includeFallback: false,
+	});
+
+	if (!apiKey) {
+		throw new Error("OpenAI Codex authentication not found. Run /login and select OpenAI Codex.");
+	}
+
+	return apiKey;
+}
+
+function buildSystemPrompt(numResults: number): string {
+	return [
+		`Research the user's query with hosted web_search and call submit_search_results exactly once with at most ${numResults} results.`,
+		"Return only real http/https URLs.",
+		"Prefer primary sources.",
+		"For snippet, write one concise sentence with the most query-relevant facts, claims, or details from the available source evidence.",
+		"For content, optionally add a longer query-relevant summary of the available source evidence; omit it if the evidence is thin or repetitive.",
+		"Do not invent details or present unsupported text as source content.",
+		"No prose.",
+		"No internal references.",
+	].join(" ");
+}
+
+export function injectCodexSearchPayload(payload: unknown): unknown {
+	const body = isRecord(payload) ? payload : {};
+	const existingTools = Array.isArray(body.tools) ? body.tools.filter(Boolean) : [];
+	const filteredTools = existingTools.filter((tool) => {
+		if (!isRecord(tool)) return true;
+		return tool.type !== "web_search";
+	});
+
+	body.tools = [
+		{
+			type: "web_search",
+			external_web_access: true,
+			search_context_size: DEFAULT_SEARCH_CONTEXT_SIZE,
+		},
+		...filteredTools,
+	];
+	body.tool_choice = "auto";
+	body.parallel_tool_calls = false;
+
+	const include = Array.isArray(body.include)
+		? body.include.filter((value): value is string => typeof value === "string")
+		: [];
+	body.include = Array.from(new Set([...include, "web_search_call.action.sources"]));
+
+	return body;
+}
+
+export function normalizeSubmitSearchResults(args: unknown, numResults: number): SearchResult[] {
+	if (!isRecord(args) || !Array.isArray(args.results)) {
+		return [];
+	}
+
+	const limit = Math.max(1, Math.min(numResults, MAX_TOOL_RESULTS));
+	const deduped = new Set<string>();
+	const results: SearchResult[] = [];
+
+	for (const rawResult of args.results) {
+		const normalized = normalizeSearchResult(rawResult);
+		if (!normalized) continue;
+
+		const dedupeKey = normalizeUrlForDedup(normalized.url);
+		if (deduped.has(dedupeKey)) continue;
+
+		deduped.add(dedupeKey);
+		results.push(normalized);
+		if (results.length >= limit) break;
+	}
+
+	return results;
+}
+
+export function normalizeSearchResult(rawResult: unknown): SearchResult | null {
+	if (!isRecord(rawResult)) return null;
+
+	const url = normalizeHttpUrl(rawResult.url);
+	if (!url) return null;
+
+	const fallbackTitle = safeUrlHostname(url);
+	const title = truncateText(cleanString(rawResult.title) || fallbackTitle, MAX_TITLE_LENGTH);
+	const content = truncateText(cleanString(rawResult.content), MAX_CONTENT_LENGTH);
+	const snippet = truncateText(cleanString(rawResult.snippet) || content, MAX_SNIPPET_LENGTH);
+
+	return {
+		title,
+		url,
+		snippet: snippet || undefined,
+		content: content || undefined,
+	};
+}
+
+function normalizeHttpUrl(value: unknown): string | undefined {
+	const input = cleanString(value);
+	if (!input) return undefined;
+
+	const candidate = hasUrlScheme(input)
+		? input
+		: looksLikeDomainOrPath(input)
+			? `https://${input}`
+			: input;
+
+	try {
+		const url = new URL(candidate);
+		if (url.protocol !== "http:" && url.protocol !== "https:") {
+			return undefined;
+		}
+		url.hash = "";
+		return url.toString();
+	} catch {
+		return undefined;
+	}
+}
+
+function normalizeUrlForDedup(url: string): string {
+	try {
+		const normalized = new URL(url);
+		normalized.hash = "";
+		normalized.pathname = normalized.pathname.replace(/\/+$/, "") || "/";
+		return normalized.toString().toLowerCase();
+	} catch {
+		return url.trim().toLowerCase();
+	}
+}
+
+function safeUrlHostname(url: string): string {
+	try {
+		return new URL(url).hostname;
+	} catch {
+		return url;
+	}
+}
+
+function cleanString(value: unknown): string {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function truncateText(value: string, maxLength: number): string {
+	return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+function hasUrlScheme(value: string): boolean {
+	return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value);
+}
+
+function looksLikeDomainOrPath(value: string): boolean {
+	return /^[^\s/]+\.[^\s]+(?:\/.*)?$/.test(value);
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+	return typeof value === "object" && value !== null;
+}

--- a/extensions/backends/openai-codex.ts
+++ b/extensions/backends/openai-codex.ts
@@ -14,7 +14,6 @@ const DEFAULT_SEARCH_CONTEXT_SIZE = "low";
 const MAX_TOOL_RESULTS = 20;
 const MAX_TITLE_LENGTH = 200;
 const MAX_SNIPPET_LENGTH = 1000;
-const MAX_CONTENT_LENGTH = 4000;
 
 const SUBMIT_SEARCH_RESULTS_TOOL = {
 	name: "submit_search_results",
@@ -30,12 +29,8 @@ const SUBMIT_SEARCH_RESULTS_TOOL = {
 				}),
 				snippet: Type.String({
 					description:
-						"One concise sentence with the most query-relevant facts, claims, or details from the available source evidence. Do not write an opinion about usefulness.",
+						"A dense 450-500 character, multi-sentence paragraph with the most query-relevant facts, claims, numbers, dates, caveats, scope limits, and source-specific details from the available source evidence. Prefer completeness and concrete details over brevity while staying within normal search-result display. Shorter is acceptable only when evidence is thin. Do not write an opinion about usefulness.",
 				}),
-				content: Type.Optional(Type.String({
-					description:
-						"Optional. A longer query-relevant summary of the available source evidence with additional concrete details beyond the snippet. Omit if evidence is thin or repetitive. Do not invent or present unsupported text as source content.",
-				})),
 			}),
 			{ maxItems: MAX_TOOL_RESULTS },
 		),
@@ -120,8 +115,7 @@ function buildSystemPrompt(numResults: number): string {
 		`Research the user's query with hosted web_search and call submit_search_results exactly once with at most ${numResults} results.`,
 		"Return only real http/https URLs.",
 		"Prefer primary sources.",
-		"For snippet, write one concise sentence with the most query-relevant facts, claims, or details from the available source evidence.",
-		"For content, optionally add a longer query-relevant summary of the available source evidence; omit it if the evidence is thin or repetitive.",
+		"For snippet, write a dense 450-500 character, multi-sentence paragraph with the most query-relevant facts, claims, numbers, dates, caveats, scope limits, and source-specific details from the available source evidence. Prefer completeness and concrete details over brevity while staying within normal search-result display. Shorter is acceptable only when evidence is thin.",
 		"Do not invent details or present unsupported text as source content.",
 		"No prose.",
 		"No internal references.",
@@ -187,14 +181,14 @@ export function normalizeSearchResult(rawResult: unknown): SearchResult | null {
 
 	const fallbackTitle = safeUrlHostname(url);
 	const title = truncateText(cleanString(rawResult.title) || fallbackTitle, MAX_TITLE_LENGTH);
-	const content = truncateText(cleanString(rawResult.content), MAX_CONTENT_LENGTH);
-	const snippet = truncateText(cleanString(rawResult.snippet) || content, MAX_SNIPPET_LENGTH);
+	const snippet = truncateText(cleanString(rawResult.snippet), MAX_SNIPPET_LENGTH);
+	if (!snippet) return null;
 
 	return {
 		title,
 		url,
-		snippet: snippet || undefined,
-		content: content || undefined,
+		snippet,
+		content: snippet,
 	};
 }
 

--- a/extensions/backends/registry.ts
+++ b/extensions/backends/registry.ts
@@ -13,6 +13,7 @@ import { searchSerper } from "./serper.js";
 import { searchTavily } from "./tavily.js";
 import { searchExa } from "./exa.js";
 import { searchExaMCP } from "./exa-mcp.js";
+import { searchOpenAICodex } from "./openai-codex.js";
 import { searchBrave } from "./brave.js";
 import { searchLangSearch } from "./langsearch.js";
 import { searchFirecrawl } from "./firecrawl.js";
@@ -117,6 +118,18 @@ export const BACKEND_DEFS: Record<string, BackendRunner> = {
 		setupLabel: "Exa MCP (zero-config, no API key needed)",
 		search: async (query, numResults, { signal }) => {
 			const result = await searchExaMCP(query, numResults, signal);
+			return { results: result.results };
+		},
+	},
+	"openai-codex": {
+		needsKey: false,
+		needsKeyFromConfig: false,
+		optionalKey: false,
+		needsInstanceUrl: false,
+		label: "OpenAI Codex",
+		setupLabel: "OpenAI Codex (experimental)",
+		search: async (query, numResults, { signal, backendConfig }) => {
+			const result = await searchOpenAICodex(query, numResults, signal, backendConfig);
 			return { results: result.results };
 		},
 	},

--- a/extensions/backends/registry.ts
+++ b/extensions/backends/registry.ts
@@ -127,7 +127,7 @@ export const BACKEND_DEFS: Record<string, BackendRunner> = {
 		optionalKey: false,
 		needsInstanceUrl: false,
 		label: "OpenAI Codex",
-		setupLabel: "OpenAI Codex (experimental)",
+		setupLabel: "OpenAI Codex",
 		search: async (query, numResults, { signal, backendConfig }) => {
 			const result = await searchOpenAICodex(query, numResults, signal, backendConfig);
 			return { results: result.results };

--- a/extensions/backends/registry.ts
+++ b/extensions/backends/registry.ts
@@ -127,7 +127,7 @@ export const BACKEND_DEFS: Record<string, BackendRunner> = {
 		optionalKey: false,
 		needsInstanceUrl: false,
 		label: "OpenAI Codex",
-		setupLabel: "OpenAI Codex",
+		setupLabel: "OpenAI Codex (draws from subscription)",
 		search: async (query, numResults, { signal, backendConfig }) => {
 			const result = await searchOpenAICodex(query, numResults, signal, backendConfig);
 			return { results: result.results };

--- a/extensions/dispatch.ts
+++ b/extensions/dispatch.ts
@@ -3,7 +3,9 @@
  */
 
 import type { SearchResult, SearchResultWithBackend } from "./types.js";
-import { config, roundRobinIndex, incrementRoundRobin, latencyMap } from "./config.js";
+
+export type BackendStats = { success: boolean; count: number; error?: string };
+import { roundRobinIndex, incrementRoundRobin } from "./config.js";
 import { scoreBackends } from "./scoring.js";
 
 // ---------------------------------------------------------------------------
@@ -38,6 +40,82 @@ export function selectBackendsForFallback(
 		default:
 			return backends;
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Targeted combine
+// ---------------------------------------------------------------------------
+
+export async function runTargetedCombine({
+	orderedBackends,
+	query,
+	numResults,
+	signal,
+	targetUsableBackends = 3,
+	runBackend,
+}: {
+	orderedBackends: string[];
+	query: string;
+	numResults: number;
+	signal?: AbortSignal;
+	targetUsableBackends?: number;
+	runBackend: (backend: string, query: string, numResults: number, signal?: AbortSignal) => Promise<SearchResult[]>;
+}): Promise<{
+	results: SearchResultWithBackend[];
+	backendStats: Map<string, BackendStats>;
+	usableBackendCount: number;
+}> {
+	const backendStats = new Map<string, BackendStats>();
+	const usableBackends: Array<{ backend: string; results: SearchResultWithBackend[] }> = [];
+	const perBackendResults = Math.max(1, Math.ceil(numResults / targetUsableBackends));
+	let cursor = 0;
+
+	while (usableBackends.length < targetUsableBackends && cursor < orderedBackends.length) {
+		const needed = targetUsableBackends - usableBackends.length;
+		const remaining = orderedBackends.length - cursor;
+		const batchSize = Math.min(needed, remaining);
+		const batch = orderedBackends.slice(cursor, cursor + batchSize);
+		cursor += batchSize;
+
+		const batchResults = await Promise.all(
+			batch.map(async (backend) => {
+				try {
+					const results = await runBackend(backend, query, perBackendResults, signal);
+					return {
+						backend,
+						results: results.map((r) => ({ ...r, backend })) as SearchResultWithBackend[],
+						success: true,
+					};
+				} catch (err) {
+					return {
+						backend,
+						results: [] as SearchResultWithBackend[],
+						success: false,
+						error: (err as Error).message,
+					};
+				}
+			}),
+		);
+
+		for (const { backend, results, success, error } of batchResults) {
+			backendStats.set(backend, {
+				success,
+				count: results.length,
+				error,
+			});
+			if (success && results.length > 0) {
+				usableBackends.push({ backend, results });
+			}
+		}
+	}
+
+	return {
+		results: usableBackends.length > 1
+			? reciprocalRankFusion(usableBackends, numResults)
+			: (usableBackends[0]?.results.slice(0, numResults) ?? []),
+		backendStats,
+		usableBackendCount: usableBackends.length,
+	};
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/openai-codex.test.ts
+++ b/extensions/openai-codex.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { streamOpenAICodexResponsesMock } = vi.hoisted(() => ({
+	streamOpenAICodexResponsesMock: vi.fn(),
+}));
 
 vi.mock("@earendil-works/pi-coding-agent", () => ({
 	AuthStorage: {
@@ -10,9 +14,7 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
 
 vi.mock("@earendil-works/pi-ai", () => ({
 	getModel: () => ({ id: "gpt-5.4-mini" }),
-	streamOpenAICodexResponses: () => ({
-		result: async () => ({ stopReason: "error", errorMessage: "not used in helper tests", content: [] }),
-	}),
+	streamOpenAICodexResponses: streamOpenAICodexResponsesMock,
 }));
 
 vi.mock("typebox", () => ({
@@ -24,7 +26,31 @@ vi.mock("typebox", () => ({
 	},
 }));
 
+beforeEach(() => {
+	streamOpenAICodexResponsesMock.mockReset();
+	streamOpenAICodexResponsesMock.mockReturnValue({
+		result: async () => ({ stopReason: "error", errorMessage: "not used in helper tests", content: [] }),
+	});
+});
+
 describe("openai-codex helpers", () => {
+	it("searchOpenAICodex asks Codex for rich source-grounded snippets", async () => {
+		const { searchOpenAICodex } = await import("./backends/openai-codex.ts");
+
+		await expect(searchOpenAICodex("test query", 3)).rejects.toThrow("not used in helper tests");
+
+		const [, context] = streamOpenAICodexResponsesMock.mock.calls[0];
+		const submitTool = context.tools[0];
+		const resultSchema = submitTool.parameters.results.value;
+
+		expect(context.systemPrompt).toContain("450-500 character");
+		expect(context.systemPrompt).toContain("normal search-result display");
+		expect(context.systemPrompt).not.toContain("For content");
+		expect(resultSchema.snippet.description).toContain("450-500 character");
+		expect(resultSchema.snippet.description).toContain("Prefer completeness and concrete details over brevity");
+		expect("content" in resultSchema).toBe(false);
+	});
+
 	it("injectCodexSearchPayload prepends hosted search and preserves function tools", async () => {
 		const { injectCodexSearchPayload } = await import("./backends/openai-codex.ts");
 
@@ -57,13 +83,14 @@ describe("openai-codex helpers", () => {
 		]);
 	});
 
-	it("normalizeSubmitSearchResults drops invalid URLs, dedupes, and falls back snippet to content", async () => {
+	it("normalizeSubmitSearchResults drops invalid URLs, dedupes, and mirrors snippet into content", async () => {
 		const { normalizeSubmitSearchResults } = await import("./backends/openai-codex.ts");
 
 		const results = normalizeSubmitSearchResults(
 			{
 				results: [
-					{ title: "", url: "example.com", content: "Primary source summary" },
+					{ title: "", url: "example.com", snippet: "Primary source summary", content: "Ignored model content" },
+					{ title: "Content only", url: "https://content-only.example/", content: "Ignored without snippet" },
 					{ title: "Duplicate", url: "https://example.com/#section", snippet: "duplicate" },
 					{ title: "Bad", url: "javascript:alert(1)", snippet: "ignore me" },
 					{ title: "Docs", url: "https://docs.digitalocean.com/reference/doctl/", snippet: "CLI docs" },
@@ -83,9 +110,22 @@ describe("openai-codex helpers", () => {
 				title: "Docs",
 				url: "https://docs.digitalocean.com/reference/doctl/",
 				snippet: "CLI docs",
-				content: undefined,
+				content: "CLI docs",
 			},
 		]);
+	});
+
+	it("normalizeSubmitSearchResults truncates mirrored snippet content to the snippet cap", async () => {
+		const { normalizeSubmitSearchResults } = await import("./backends/openai-codex.ts");
+		const longSnippet = "x".repeat(1100);
+
+		const [result] = normalizeSubmitSearchResults(
+			{ results: [{ title: "Long", url: "https://example.com/long", snippet: longSnippet }] },
+			1,
+		);
+
+		expect(result.snippet).toHaveLength(1000);
+		expect(result.content).toHaveLength(1000);
 	});
 
 	it("normalizeSubmitSearchResults returns empty for malformed tool arguments", async () => {

--- a/extensions/openai-codex.test.ts
+++ b/extensions/openai-codex.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+	AuthStorage: {
+		create: () => ({
+			getApiKey: async () => "test-api-key",
+		}),
+	},
+}));
+
+vi.mock("@earendil-works/pi-ai", () => ({
+	getModel: () => ({ id: "gpt-5.4-mini" }),
+	streamOpenAICodexResponses: () => ({
+		result: async () => ({ stopReason: "error", errorMessage: "not used in helper tests", content: [] }),
+	}),
+}));
+
+vi.mock("typebox", () => ({
+	Type: {
+		Object: (value: unknown) => value,
+		String: (value?: unknown) => value ?? {},
+		Optional: (value: unknown) => value,
+		Array: (value: unknown, options?: unknown) => ({ value, options }),
+	},
+}));
+
+describe("openai-codex helpers", () => {
+	it("injectCodexSearchPayload prepends hosted search and preserves function tools", async () => {
+		const { injectCodexSearchPayload } = await import("./backends/openai-codex.ts");
+
+		const payload = injectCodexSearchPayload({
+			tools: [
+				{ type: "web_search", external_web_access: false },
+				{ type: "function", name: "submit_search_results" },
+			],
+			include: ["reasoning.encrypted_content"],
+			parallel_tool_calls: true,
+		}) as {
+			tools: Array<Record<string, unknown>>;
+			include: string[];
+			parallel_tool_calls: boolean;
+			tool_choice: string;
+		};
+
+		expect(payload.tools).toHaveLength(2);
+		expect(payload.tools[0]).toMatchObject({
+			type: "web_search",
+			external_web_access: true,
+			search_context_size: "low",
+		});
+		expect(payload.tools[1]).toMatchObject({ type: "function", name: "submit_search_results" });
+		expect(payload.parallel_tool_calls).toBe(false);
+		expect(payload.tool_choice).toBe("auto");
+		expect(payload.include).toEqual([
+			"reasoning.encrypted_content",
+			"web_search_call.action.sources",
+		]);
+	});
+
+	it("normalizeSubmitSearchResults drops invalid URLs, dedupes, and falls back snippet to content", async () => {
+		const { normalizeSubmitSearchResults } = await import("./backends/openai-codex.ts");
+
+		const results = normalizeSubmitSearchResults(
+			{
+				results: [
+					{ title: "", url: "example.com", content: "Primary source summary" },
+					{ title: "Duplicate", url: "https://example.com/#section", snippet: "duplicate" },
+					{ title: "Bad", url: "javascript:alert(1)", snippet: "ignore me" },
+					{ title: "Docs", url: "https://docs.digitalocean.com/reference/doctl/", snippet: "CLI docs" },
+				],
+			},
+			2,
+		);
+
+		expect(results).toEqual([
+			{
+				title: "example.com",
+				url: "https://example.com/",
+				snippet: "Primary source summary",
+				content: "Primary source summary",
+			},
+			{
+				title: "Docs",
+				url: "https://docs.digitalocean.com/reference/doctl/",
+				snippet: "CLI docs",
+				content: undefined,
+			},
+		]);
+	});
+
+	it("normalizeSubmitSearchResults returns empty for malformed tool arguments", async () => {
+		const { normalizeSubmitSearchResults } = await import("./backends/openai-codex.ts");
+
+		expect(normalizeSubmitSearchResults({}, 5)).toEqual([]);
+		expect(normalizeSubmitSearchResults({ results: "not-an-array" }, 5)).toEqual([]);
+	});
+});

--- a/extensions/search-hub.ts
+++ b/extensions/search-hub.ts
@@ -93,7 +93,7 @@ export default function (pi: ExtensionAPI) {
 			),
 			backend: Type.Optional(
 				StringEnum(["duckduckgo", "jina", "marginalia", "serper", "tavily", "exa", "exa_mcp",
-					"brave", "brave-llm", "langsearch", "firecrawl", "websearchapi", "perplexity",
+					"openai-codex", "brave", "brave-llm", "langsearch", "firecrawl", "websearchapi", "perplexity",
 					"searxng", "linkup", "youcom", "fastcrw", "sofya", "auto"] as const, {
 					description:
 						"Backend to use. 'auto' picks the best configured backend (default)",

--- a/extensions/search-hub.ts
+++ b/extensions/search-hub.ts
@@ -1,5 +1,5 @@
 /**
- * Extension — Unified web search (18 backends) + content extraction (web_read)
+ * Extension — Unified web search (19 backends) + content extraction (web_read)
  *
  * Backends (choose any, all disabled by default):
  *   duckduckgo    — ✅ Free, no key, via Python ddgs lib. Rate-limited.
@@ -15,7 +15,7 @@
  *   perplexity    — ✅ Unlimited free Sonar, citation-based answers
  *   searxng       — ✅ Self-hosted, 70+ aggregators. Needs instance URL
  *
- * Tools: web_search (auto-fallback + RRF combine mode), web_read (URL content)
+ * Tools: web_search (auto-fallback + RRF combine modes), web_read (URL content)
  * Config: ~/.pi/agent/extensions/search.json + .pi/search.json (project wins)
  * Credentials: env var refs (ALL_CAPS), shell commands (!command), or literal keys
  *
@@ -51,7 +51,7 @@ import { resolveBackendKey, getKeySource } from "./credentials.js";
 import { fetchSofya } from "./backends/sofya.js";
 import { config, refreshConfig, getActiveBackends, recordLatency, latencyMap } from "./config.js";
 import { BACKEND_DEFS, runBackend } from "./backends/registry.js";
-import { selectBackendsForFallback, reciprocalRankFusion } from "./dispatch.js";
+import { selectBackendsForFallback, reciprocalRankFusion, runTargetedCombine } from "./dispatch.js";
 import { formatResults, formatCombinedResults, formatResultsCompact, formatCombinedResultsCompact } from "./formatters.js";
 
 // ---------------------------------------------------------------------------
@@ -78,7 +78,8 @@ export default function (pi: ExtensionAPI) {
 		promptGuidelines: [
 			"Use web_search when you need up-to-date information, facts, or documentation from the web",
 			"Auto mode tries enabled backends in order (DuckDuckGo is the free fallback)",
-			"Set combine=true to query ALL backends in parallel and merge/deduplicate results",
+			"Set combine=true to query enabled backends in parallel and merge/deduplicate results",
+			"Set combineMode=targeted in search.json to cap combine fan-out while still using multiple backends",
 			"Configure additional backends in .pi/search.json for better quality results",
 		],
 		parameters: Type.Object({
@@ -102,7 +103,8 @@ export default function (pi: ExtensionAPI) {
 			combine: Type.Optional(
 				Type.Boolean({
 					description:
-						"When true, queries ALL enabled backends in parallel and merges/deduplicates results. " +
+						"When true, queries enabled backends in parallel and merges/deduplicates results. " +
+						"Config combineMode controls whether this uses all backends or targeted fan-out. " +
 						"Default is false (fallback mode: uses first successful backend only). " +
 						"Ignored when a specific backend is requested (backend != 'auto').",
 					default: false,
@@ -123,6 +125,7 @@ export default function (pi: ExtensionAPI) {
 			const requestedBackend = params.backend || "auto";
 			const combine = params.combine ?? false;
 			const compact = params.compact ?? config.compact ?? false;
+			const combineMode = config.combineMode ?? "all";
 			// If config has combine:true, force combine mode regardless of LLM choice
 			const forceCombine = config.combine === true;
 			const effectiveCombine = forceCombine || combine;
@@ -154,6 +157,56 @@ export default function (pi: ExtensionAPI) {
 			const activeBackends = getActiveBackends();
 
 			if (effectiveCombine) {
+				if (combineMode === "targeted") {
+					const orderedBackends = selectBackendsForFallback(
+						config.selectionStrategy ?? "sequential",
+						activeBackends,
+					);
+					setStatus(`🔍 targeted combine: up to 3 of ${activeBackends.length} backends...`);
+					const {
+						results: combined,
+						backendStats,
+						usableBackendCount,
+					} = await runTargetedCombine({
+						orderedBackends,
+						query: params.query,
+						numResults,
+						signal,
+						runBackend,
+					});
+
+					if (usableBackendCount === 0) {
+						setStatus(`❌ targeted combine: no usable backends`);
+						const errors = Array.from(backendStats.entries()).map(([backend, stats]) => (
+							stats.success
+								? `${backend}: 0 results`
+								: `${backend}: ${stats.error || "failed"}`
+						));
+						throw new Error(`Targeted combine found no usable backend results: ${errors.join("; ")}`);
+					}
+
+					const attemptedCount = backendStats.size;
+					const incomplete = usableBackendCount < 3 ? `, exhausted after ${usableBackendCount} usable` : "";
+					setStatus(`🔍 targeted combined: ${combined.length} results (${usableBackendCount}/${attemptedCount} usable${incomplete})`);
+
+					return {
+						content: [
+							{
+								type: "text",
+								text: compact
+									? formatCombinedResultsCompact(combined)
+									: formatCombinedResults(params.query, combined, backendStats, BACKEND_DEFS),
+							},
+						],
+						details: {
+							backend: "combined-targeted",
+							resultCount: combined.length,
+							usableBackendCount,
+							backendStats: Object.fromEntries(backendStats),
+						},
+					};
+				}
+
 				// Combine mode: query all enabled backends in parallel
 				setStatus(`🔍 combine: ${activeBackends.length} backends...`);
 				const resultsPerBackend = await Promise.all(
@@ -657,6 +710,7 @@ export default function (pi: ExtensionAPI) {
 			["compact", "Compact output", existing.compact ? "On" : "Off"],
 			["showStatus", "Show status line", existing.showStatus !== false ? "On" : "Off"],
 			["combine", "Combine mode (parallel search)", existing.combine ? "On" : "Off"],
+			["combineMode", "Combine strategy", existing.combineMode ?? "all"],
 			["cacheTtl", "Cache TTL (ms)", String(existing.cacheTtl ?? 300000)],
 			["cacheMax", "Max cached queries", String(existing.cacheMax ?? 100)],
 			["reader", "Web reader", existing.reader ?? "jina"],
@@ -692,6 +746,15 @@ export default function (pi: ExtensionAPI) {
 					return;
 				}
 				value = toggle === "On";
+				break;
+			}
+			case "combineMode": {
+				const choice = await ctx.ui.select(`${label} — current: ${selected.split(": ")[1]}`, ["all", "targeted", "Cancel"]);
+				if (choice === "Cancel" || !choice) {
+					ctx.ui.notify("Setup cancelled.", "info");
+					return;
+				}
+				value = choice;
 				break;
 			}
 			case "cacheTtl":
@@ -797,6 +860,7 @@ export default function (pi: ExtensionAPI) {
 				"## Search Backend Status",
 				`Configured default: ${config.defaultBackend || "none"}`,
 				`Resolved default: ${resolvedDefault}`,
+				`Combine mode: ${config.combine ? (config.combineMode || "all") : "off"}`,
 				`Strategy: ${config.selectionStrategy || "sequential"}`,
 				`Active: ${activeBackends.join(", ") || "none"}`,
 				"",

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -36,6 +36,8 @@ export interface BackendConfig {
 export interface SearchConfig {
 	defaultBackend?: string;
 	combine?: boolean;
+	/** Combine strategy when combine is enabled. "all" queries every active backend; "targeted" queries only enough ordered backends to collect up to 3 usable result sets. */
+	combineMode?: "all" | "targeted";
 	selectionStrategy?: "sequential" | "random" | "round-robin" | "best-latency";
 	/** Reader backend for web_read. "jina" (default, free) or "sofya" (250+ site parsers, needs key). */
 	reader?: "jina" | "sofya";

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -55,6 +55,7 @@ export interface SearchConfig {
 		tavily?: BackendConfig;
 		exa?: BackendConfig;
 		exa_mcp?: BackendConfig;
+		"openai-codex"?: BackendConfig;
 		brave?: BackendConfig;
 		braveLLM?: BackendConfig;
 		"brave-llm"?: BackendConfig;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-search-hub",
   "version": "2.3.3",
-  "description": "Unified web search + content extraction extension for pi with 17 backends (DuckDuckGo, Jina AI, Tavily, Brave, Brave LLM, Exa, Serper, Firecrawl, fastCRW, Marginalia, LangSearch, Linkup, Perplexity Sonar, SearXNG, WebSearchAPI, You.com, Sofya). Auto-fallback, RRF combine mode, pluggable web_read reader (Jina or Sofya), secure credential resolution.",
+  "description": "Unified web search + content extraction extension for pi with 19 backends (DuckDuckGo, Jina AI, Tavily, Brave, Brave LLM, Exa, Exa MCP, OpenAI Codex, Serper, Firecrawl, fastCRW, Marginalia, LangSearch, Linkup, Perplexity Sonar, SearXNG, WebSearchAPI, You.com, Sofya). Auto-fallback, RRF combine mode, pluggable web_read reader (Jina or Sofya), secure credential resolution.",
   "keywords": [
     "pi-package",
     "pi",
@@ -26,6 +26,7 @@
     "linkup",
     "youcom",
     "sofya",
+    "openai-codex",
     "rrf",
     "ai-agent"
   ],

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { reciprocalRankFusion, selectBackendsForFallback } from "../extensions/dispatch.js";
+import { reciprocalRankFusion, runTargetedCombine, selectBackendsForFallback } from "../extensions/dispatch.js";
 import { resolveConfigValue, clearCredentialCache } from "../extensions/credentials.js";
 import { loadConfig } from "../extensions/config.js";
 import { SearchCache } from "../extensions/utils.js";
@@ -121,6 +121,96 @@ describe("reciprocalRankFusion", () => {
 	it("returns empty array when no successful backends", () => {
 		const results = reciprocalRankFusion([], 10);
 		expect(results).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Targeted combine tests
+// ---------------------------------------------------------------------------
+
+describe("runTargetedCombine", () => {
+	const resultFor = (backend: string) => [{
+		title: `${backend} result`,
+		url: `https://example.com/${backend}`,
+		snippet: `${backend} snippet`,
+	}];
+
+	it("stops after the first three usable backends", async () => {
+		const calls: Array<{ backend: string; numResults: number }> = [];
+		const result = await runTargetedCombine({
+			orderedBackends: ["a", "b", "c", "d"],
+			query: "test query",
+			numResults: 10,
+			runBackend: async (backend, _query, numResults) => {
+				calls.push({ backend, numResults });
+				return resultFor(backend);
+			},
+		});
+
+		expect(calls).toEqual([
+			{ backend: "a", numResults: 4 },
+			{ backend: "b", numResults: 4 },
+			{ backend: "c", numResults: 4 },
+		]);
+		expect(result.usableBackendCount).toBe(3);
+		expect(result.results).toHaveLength(3);
+		expect(Array.from(result.backendStats.keys())).toEqual(["a", "b", "c"]);
+	});
+
+	it("tops up only the missing usable backend count", async () => {
+		const calls: string[] = [];
+		const result = await runTargetedCombine({
+			orderedBackends: ["a", "b", "c", "d", "e"],
+			query: "test query",
+			numResults: 9,
+			runBackend: async (backend) => {
+				calls.push(backend);
+				if (backend === "b") throw new Error("b failed");
+				return resultFor(backend);
+			},
+		});
+
+		expect(calls).toEqual(["a", "b", "c", "d"]);
+		expect(result.usableBackendCount).toBe(3);
+		expect(result.backendStats.get("b")).toMatchObject({ success: false, count: 0, error: "b failed" });
+		expect(result.backendStats.has("e")).toBe(false);
+	});
+
+	it("runs the next three when the first three are not usable", async () => {
+		const calls: string[] = [];
+		const result = await runTargetedCombine({
+			orderedBackends: ["a", "b", "c", "d", "e", "f", "g"],
+			query: "test query",
+			numResults: 6,
+			runBackend: async (backend) => {
+				calls.push(backend);
+				if (["a", "b", "c"].includes(backend)) return [];
+				return resultFor(backend);
+			},
+		});
+
+		expect(calls).toEqual(["a", "b", "c", "d", "e", "f"]);
+		expect(result.usableBackendCount).toBe(3);
+		expect(result.backendStats.get("a")).toMatchObject({ success: true, count: 0 });
+		expect(result.backendStats.has("g")).toBe(false);
+	});
+
+	it("returns partial results when active backends are exhausted", async () => {
+		const result = await runTargetedCombine({
+			orderedBackends: ["a", "b", "c"],
+			query: "test query",
+			numResults: 10,
+			runBackend: async (backend) => {
+				if (backend === "a") return resultFor(backend);
+				if (backend === "b") return [];
+				throw new Error("c failed");
+			},
+		});
+
+		expect(result.usableBackendCount).toBe(1);
+		expect(result.results).toEqual([{ ...resultFor("a")[0], backend: "a" }]);
+		expect(result.backendStats.get("b")).toMatchObject({ success: true, count: 0 });
+		expect(result.backendStats.get("c")).toMatchObject({ success: false, count: 0, error: "c failed" });
 	});
 });
 


### PR DESCRIPTION
## Summary

This PR now includes two related search improvements:

1. **Add an `openai-codex` search backend**
   - Uses Pi-managed OpenAI Codex auth via `AuthStorage` / Pi `/login` instead of `search.json` API keys
   - Calls Pi AI's Codex Responses provider
   - Injects hosted `web_search`
   - Normalizes Codex tool output into standard `SearchResult` objects

2. **Add config-only targeted combine mode**
   - Introduces `combineMode: "all" | "targeted"` in `search.json`
   - Lets auto+combine mode query only enough ordered backends to collect up to 3 usable result sets, instead of always fanning out to every enabled backend
   - Preserves the existing `web_search` tool API; this is configured through search config, not a new tool parameter

## What changed

### OpenAI Codex backend

- Added `extensions/backends/openai-codex.ts`
- Registered `openai-codex` in the backend registry, config typing, and `web_search` backend enum
- Added setup/status/docs support for a Pi-auth-backed Codex backend
- Default model is `gpt-5.4-mini`, configurable via `backends.openai-codex.model`
- Setup label clarifies that Codex draws from the user's Pi/OpenAI Codex subscription

### Codex result shaping

- Codex now generates a single dense `snippet` per result
- The backend no longer asks the model for a separate `content` field, reducing output tokens and duplicate summarization work
- Returned `SearchResult.content` is mirrored from `snippet` for downstream compatibility and combine-mode richness
- Snippets are tuned to fit normal search-result display instead of generating text that the shared formatter would truncate
- Results without a valid URL or non-empty snippet are discarded during normalization

### Targeted combine mode

- Added `combineMode?: "all" | "targeted"` to `SearchConfig`
- Added `runTargetedCombine()` in `extensions/dispatch.ts`
- Wired the `web_search` auto+combine flow to honor `combineMode`
- `targeted` mode:
  - orders backends using the existing selection strategy
  - queries only the next needed batch of backends
  - stops after collecting up to 3 usable non-empty backend result sets
  - returns partial usable results if the backend list is exhausted
- `/search-setup`, `/search-status`, and README now document/show the active combine mode

## Notes

- **No `web_search` API expansion**: targeted combine is config-only
- **OpenAI Codex auth is Pi-managed**: enable the backend in `search.json`, then run `/login` in Pi and select OpenAI Codex
- **Codex may return fewer than requested results** when it only finds a smaller set of strong source-grounded candidates
- **Targeted combine** is meant to reduce overkill/quota burn compared to querying every enabled backend in parallel

## Validation

### Automated

- `npx vitest run extensions/openai-codex.test.ts`
- `HOME=$(mktemp -d) npx vitest run`

### Coverage added/updated

- Codex helper tests for:
  - hosted `web_search` payload injection
  - prompt/schema contract
  - result normalization/dedupe
  - snippet mirroring into `content`
  - invalid/empty result handling
- Integration coverage for `runTargetedCombine`:
  - stops after the first 3 usable backends
  - tops up after failures
  - skips unusable early batches
  - returns partial usable results when backends are exhausted

### Manual/live

- Live-tested the Codex backend through Pi
- Verified after reload that Codex search returns dense multi-sentence snippets instead of the previous short one-sentence shape