### PR TITLE
fix(fallback): keep trying backends when one returns zero results

### DIFF
--- a/extensions/dispatch.ts
+++ b/extensions/dispatch.ts
@@ -5,7 +5,7 @@
 import type { SearchResult, SearchResultWithBackend } from "./types.js";
 
 export type BackendStats = { success: boolean; count: number; error?: string };
-import { config, roundRobinIndex, incrementRoundRobin } from "./config.js";
+import { config, roundRobinIndex, incrementRoundRobin, recordLatency } from "./config.js";
 import { scoreBackends } from "./scoring.js";
 
 // ---------------------------------------------------------------------------
@@ -41,6 +41,77 @@ export function selectBackendsForFallback(
 		default:
 			return backends;
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Fallback chain
+// ---------------------------------------------------------------------------
+
+export type FallbackEvent =
+	| { type: "start"; backend: string }
+	| { type: "results"; backend: string; count: number }
+	| { type: "empty"; backend: string }
+	| { type: "error"; backend: string; message: string };
+
+export interface FallbackOutcome {
+	/** Backend that returned non-empty results, or null when none did. */
+	backend: string | null;
+	results: SearchResult[];
+	/** "<backend>: <message>" for every backend that threw. */
+	errors: string[];
+	/** Backends that resolved successfully but returned zero results. */
+	emptyBackends: string[];
+}
+
+/**
+ * Try each backend in order until one returns non-empty results.
+ *
+ * A backend that resolves with zero results is treated as unusable and the chain
+ * continues. Several providers signal quota exhaustion, rate limiting or a blocked
+ * region with an empty 200 body rather than an error status, so stopping at the
+ * first non-throwing backend would hand the model an empty answer while usable
+ * backends sit untried. This matches runTargetedCombine, which already requires
+ * non-empty results for a backend to count as usable.
+ */
+export async function runFallbackChain({
+	orderedBackends,
+	query,
+	numResults,
+	signal,
+	runBackend,
+	onEvent,
+}: {
+	orderedBackends: string[];
+	query: string;
+	numResults: number;
+	signal?: AbortSignal;
+	runBackend: (backend: string, query: string, numResults: number, signal?: AbortSignal) => Promise<SearchResult[]>;
+	onEvent?: (event: FallbackEvent) => void;
+}): Promise<FallbackOutcome> {
+	const errors: string[] = [];
+	const emptyBackends: string[] = [];
+
+	for (const backend of orderedBackends) {
+		onEvent?.({ type: "start", backend });
+		const startedAt = Date.now();
+		try {
+			const results = await runBackend(backend, query, numResults, signal);
+			recordLatency(backend, Date.now() - startedAt);
+			if (results.length === 0) {
+				emptyBackends.push(backend);
+				onEvent?.({ type: "empty", backend });
+				continue;
+			}
+			onEvent?.({ type: "results", backend, count: results.length });
+			return { backend, results, errors, emptyBackends };
+		} catch (err) {
+			const message = (err as Error).message;
+			errors.push(`${backend}: ${message}`);
+			onEvent?.({ type: "error", backend, message });
+		}
+	}
+
+	return { backend: null, results: [], errors, emptyBackends };
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/search-hub.ts
+++ b/extensions/search-hub.ts
@@ -49,9 +49,9 @@ import type { BackendConfig, SearchConfig, SearchResult, SearchResultWithBackend
 import { getAgentDir, clearCooldowns, validateUrl } from "./utils.js";
 import { getKeySource } from "./credentials.js";
 import { fetchWithReader, fetchWithFallback, readerLabel, DEFAULT_READER_FALLBACK } from "./readers/dispatch.js";
-import { config, refreshConfig, getActiveBackends, recordLatency, latencyMap } from "./config.js";
+import { config, refreshConfig, getActiveBackends, latencyMap } from "./config.js";
 import { BACKEND_DEFS, runBackend } from "./backends/registry.js";
-import { selectBackendsForFallback, reciprocalRankFusion, runTargetedCombine } from "./dispatch.js";
+import { selectBackendsForFallback, reciprocalRankFusion, runTargetedCombine, runFallbackChain } from "./dispatch.js";
 import { formatResults, formatCombinedResults, formatResultsCompact, formatCombinedResultsCompact } from "./formatters.js";
 
 
@@ -291,38 +291,61 @@ export default function (pi: ExtensionAPI) {
 					config.selectionStrategy ?? "sequential",
 					activeBackends,
 				);
-				const errors: string[] = [];
-				for (const backend of orderedBackends) {
-					const backendLabel = BACKEND_DEFS[backend]?.label || backend;
-					const t0 = Date.now();
-					setStatus(`🔍 ${backendLabel}: searching...`);
-					try {
-						const results = await runBackend(backend, params.query, numResults, signal);
-						recordLatency(backend, Date.now() - t0);
-						setStatus(`🔍 ${backendLabel}: ${results.length} results`);
-						return {
-							content: [
-								{
-									type: "text",
-									text: errors.length > 0
-										? `${errors.join("; ")}\n\n${compact ? formatResultsCompact(results) : formatResults(params.query, backend, results)}`
-										: (compact ? formatResultsCompact(results) : formatResults(params.query, backend, results)),
-								},
-							],
-							details: {
-								backend: errors.length > 0 ? `${backend} (fallback)` : backend,
-								resultCount: results.length,
-								errors: errors.length > 0 ? errors : undefined,
-							},
-						};
-					} catch (err) {
-						errors.push(`${backend}: ${(err as Error).message}`);
-						setStatus(`❌ ${backendLabel}: failed, trying next...`);
-					}
+				const { backend, results, errors, emptyBackends } = await runFallbackChain({
+					orderedBackends,
+					query: params.query,
+					numResults,
+					signal,
+					runBackend,
+					onEvent: (event) => {
+						const backendLabel = BACKEND_DEFS[event.backend]?.label || event.backend;
+						switch (event.type) {
+							case "start":
+								setStatus(`🔍 ${backendLabel}: searching...`);
+								break;
+							case "results":
+								setStatus(`🔍 ${backendLabel}: ${event.count} results`);
+								break;
+							case "empty":
+								setStatus(`⚠️ ${backendLabel}: no results, trying next...`);
+								break;
+							case "error":
+								setStatus(`❌ ${backendLabel}: failed, trying next...`);
+								break;
+						}
+					},
+				});
+
+				if (backend === null && emptyBackends.length === 0) {
+					setStatus(`❌ all backends failed`);
+					throw new Error(`All backends failed: ${errors.join("; ")}`);
 				}
 
-				setStatus(`❌ all backends failed`);
-				throw new Error(`All backends failed: ${errors.join("; ")}`);
+				// Every backend returning zero results is a legitimate answer for an
+				// obscure query, so report the empty result set instead of failing.
+				if (backend === null) {
+					setStatus(`🔍 no results from ${emptyBackends.length} backend(s)`);
+				}
+
+				const servedBy = backend ?? emptyBackends[emptyBackends.length - 1];
+				const notes = [...errors, ...emptyBackends.map(b => `${b}: no results`)];
+				const body = compact
+					? formatResultsCompact(results)
+					: formatResults(params.query, servedBy, results);
+
+				return {
+					content: [
+						{
+							type: "text",
+							text: notes.length > 0 ? `${notes.join("; ")}\n\n${body}` : body,
+						},
+					],
+					details: {
+						backend: notes.length > 0 ? `${servedBy} (fallback)` : servedBy,
+						resultCount: results.length,
+						errors: errors.length > 0 ? errors : undefined,
+					},
+				};
 			}
 		},
 	});

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { reciprocalRankFusion, runTargetedCombine, selectBackendsForFallback } from "../extensions/dispatch.js";
+import { reciprocalRankFusion, runFallbackChain, runTargetedCombine, selectBackendsForFallback } from "../extensions/dispatch.js";
 import { recordBackendSuccess, recordBackendFailure } from "../extensions/scoring.js";
 import { resolveConfigValue, clearCredentialCache } from "../extensions/credentials.js";
 import { loadConfig } from "../extensions/config.js";
@@ -127,6 +127,134 @@ describe("reciprocalRankFusion", () => {
 
 // ---------------------------------------------------------------------------
 // Targeted combine tests
+// ---------------------------------------------------------------------------
+
+describe("runFallbackChain", () => {
+	const resultFor = (backend: string) => [{
+		title: `${backend} result`,
+		url: `https://example.com/${backend}`,
+		snippet: `${backend} snippet`,
+	}];
+
+	it("returns the first backend that yields non-empty results", async () => {
+		const calls: string[] = [];
+		const outcome = await runFallbackChain({
+			orderedBackends: ["a", "b", "c"],
+			query: "test query",
+			numResults: 5,
+			runBackend: async (backend) => {
+				calls.push(backend);
+				return resultFor(backend);
+			},
+		});
+
+		expect(calls).toEqual(["a"]);
+		expect(outcome.backend).toBe("a");
+		expect(outcome.results).toHaveLength(1);
+		expect(outcome.errors).toEqual([]);
+		expect(outcome.emptyBackends).toEqual([]);
+	});
+
+	it("falls through a backend that returns zero results", async () => {
+		const calls: string[] = [];
+		const outcome = await runFallbackChain({
+			orderedBackends: ["a", "b", "c"],
+			query: "test query",
+			numResults: 5,
+			runBackend: async (backend) => {
+				calls.push(backend);
+				return backend === "a" ? [] : resultFor(backend);
+			},
+		});
+
+		expect(calls).toEqual(["a", "b"]);
+		expect(outcome.backend).toBe("b");
+		expect(outcome.emptyBackends).toEqual(["a"]);
+		expect(outcome.errors).toEqual([]);
+	});
+
+	it("falls through both empty and throwing backends", async () => {
+		const calls: string[] = [];
+		const outcome = await runFallbackChain({
+			orderedBackends: ["a", "b", "c"],
+			query: "test query",
+			numResults: 5,
+			runBackend: async (backend) => {
+				calls.push(backend);
+				if (backend === "a") return [];
+				if (backend === "b") throw new Error("b rate limited");
+				return resultFor(backend);
+			},
+		});
+
+		expect(calls).toEqual(["a", "b", "c"]);
+		expect(outcome.backend).toBe("c");
+		expect(outcome.emptyBackends).toEqual(["a"]);
+		expect(outcome.errors).toEqual(["b: b rate limited"]);
+	});
+
+	it("reports no serving backend when every backend is empty", async () => {
+		const outcome = await runFallbackChain({
+			orderedBackends: ["a", "b"],
+			query: "test query",
+			numResults: 5,
+			runBackend: async () => [],
+		});
+
+		expect(outcome.backend).toBeNull();
+		expect(outcome.results).toEqual([]);
+		expect(outcome.emptyBackends).toEqual(["a", "b"]);
+		expect(outcome.errors).toEqual([]);
+	});
+
+	it("collects every error when all backends throw", async () => {
+		const outcome = await runFallbackChain({
+			orderedBackends: ["a", "b"],
+			query: "test query",
+			numResults: 5,
+			runBackend: async (backend) => {
+				throw new Error(`${backend} down`);
+			},
+		});
+
+		expect(outcome.backend).toBeNull();
+		expect(outcome.emptyBackends).toEqual([]);
+		expect(outcome.errors).toEqual(["a: a down", "b: b down"]);
+	});
+
+	it("emits start/empty/results events in order", async () => {
+		const events: string[] = [];
+		await runFallbackChain({
+			orderedBackends: ["a", "b"],
+			query: "test query",
+			numResults: 5,
+			runBackend: async (backend) => (backend === "a" ? [] : resultFor(backend)),
+			onEvent: (event) => {
+				events.push(event.type === "results" ? `results:${event.backend}:${event.count}` : `${event.type}:${event.backend}`);
+			},
+		});
+
+		expect(events).toEqual(["start:a", "empty:a", "start:b", "results:b:1"]);
+	});
+
+	it("returns no serving backend for an empty backend list", async () => {
+		const outcome = await runFallbackChain({
+			orderedBackends: [],
+			query: "test query",
+			numResults: 5,
+			runBackend: async () => {
+				throw new Error("should not be called");
+			},
+		});
+
+		expect(outcome.backend).toBeNull();
+		expect(outcome.errors).toEqual([]);
+		expect(outcome.emptyBackends).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Targeted combine
 // ---------------------------------------------------------------------------
 
 describe("runTargetedCombine", () => {


### PR DESCRIPTION
## Problem

In fallback mode (`combine: false`), the chain returns the **first backend that does not throw** — even when that backend returned zero results:

https://github.com/ronnieops/pi-search-hub/blob/main/extensions/search-hub.ts#L299-L317

`runBackend` only throws on configuration and HTTP errors; a `200` with an empty body resolves normally. Several providers signal quota exhaustion, rate limiting, or a blocked region exactly that way. When one of them is early in the chain, the search ends there and the model receives an empty answer while perfectly usable backends further down are never tried.

This is also inconsistent with `runTargetedCombine`, which already treats non-empty results as the condition for a backend being "usable".

### Reproduction

Point `searxng` at an endpoint that always answers `200 {"results": []}`, order it ahead of a working backend, and search:

```json
{
  "backends": {
    "searxng":   { "enabled": true, "instanceUrl": "http://127.0.0.1:8899" },
    "firecrawl": { "enabled": true }
  }
}
```

| | Result |
|---|---|
| before | `Backend: searxng · Results: 0` — firecrawl never called |
| after  | `Backend: firecrawl · Results: 10`, with `searxng: no results` noted |

## Change

- Extract the fallback loop into `runFallbackChain` in `dispatch.ts`, next to the existing `runTargetedCombine` and with the same injected-`runBackend` shape, so it is unit-testable.
- Treat a zero-result response as unusable and continue down the chain.
- When **every** backend returns nothing, still return the empty result set instead of throwing — no results is a legitimate answer for an obscure query. `All backends failed` is now raised only when every backend actually threw.
- Skipped backends appear in the tool output the same way failed ones already did, and a new `⚠️ <backend>: no results, trying next...` status makes the fall-through visible in the TUI.

Behaviour is unchanged whenever the first backend returns results, which is the common path.

## Tests

Seven cases added to `tests/integration.test.ts` covering: first backend wins, fall-through on empty, mixed empty + throwing, all-empty, all-throwing, event ordering, and an empty backend list.

```
Tests  181 passed | 1 failed (182)
```

The one failure is pre-existing and unrelated — `loadConfig > returns default config when no config files exist` fails on any machine that actually has `~/.pi/agent/extensions/search.json`, because `loadConfig` reads the real global config path (`extensions/config.ts:47`). It fails identically with this branch stashed. Happy to fix that test isolation in a separate PR if useful.

`tsc --noEmit` reports the same 20 pre-existing errors before and after this change; none are in the touched files.

## Verified end-to-end

Beyond the unit tests, the patched extension was loaded into a real pi install and exercised against the stub above: fall-through confirmed, and the all-empty case confirmed to return `isError: false` with a zero-result set rather than throwing.