### PR TITLE
feat: add configurable per-backend request throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ Configure backends globally (all projects) or per-project:
     "perplexity": {
       "enabled": true,
       "apiKey": "PERPLEXITY_API_KEY",
-      "model": "sonar"
+      "model": "sonar",
+      "requestIntervalMs": 1500
     },
     "searxng": { "enabled": true, "instanceUrl": "http://localhost:8888" },
     "linkup": { "enabled": true, "apiKey": "LINKUP_API_KEY" },
@@ -171,6 +172,26 @@ Configure backends globally (all projects) or per-project:
   }
 }
 ```
+
+### Per-backend request throttling
+
+Set `requestIntervalMs` to enforce a minimum interval between request starts for a backend. Reservations are serialized across concurrent `web_search` calls, preventing parallel calls from racing past providers' requests-per-second limits.
+
+For example, Perplexity enforces a 1 TPS limit on some accounts. A 1.5 second interval provides some scheduling and network-latency headroom:
+
+```json
+{
+  "backends": {
+    "perplexity": {
+      "enabled": true,
+      "apiKey": "PERPLEXITY_API_KEY",
+      "requestIntervalMs": 1500
+    }
+  }
+}
+```
+
+The default is `2000` ms for backward compatibility. Set it to `0` to disable throttling for a backend.
 
 ### Credential Resolution
 

--- a/extensions/backends/registry.ts
+++ b/extensions/backends/registry.ts
@@ -3,7 +3,7 @@
  */
 
 import type { BackendRunner, BackendConfig, SearchResult } from "../types.js";
-import { MISSING_KEY_HELP, waitForCooldown, markCooldown, searchCache, cacheKey } from "../utils.js";
+import { MISSING_KEY_HELP, waitForCooldown, searchCache, cacheKey } from "../utils.js";
 import { resolveBackendKey } from "../credentials.js";
 import { config } from "../config.js";
 import { recordBackendSuccess, recordBackendFailure } from "../scoring.js";
@@ -292,7 +292,6 @@ export async function runBackend(
 		if (cached) return cached;
 	}
 
-	await waitForCooldown(backend);
 	const def = BACKEND_DEFS[backend];
 	if (!def) throw new Error(`Unknown backend: ${backend}`);
 
@@ -321,6 +320,7 @@ export async function runBackend(
 	}
 
 	const bc = (config.backends as Record<string, BackendConfig> | undefined)?.[backend];
+	await waitForCooldown(backend, bc?.requestIntervalMs);
 	const startTime = Date.now();
 	try {
 		const result = await def.search(query, numResults, { key, instanceUrl, signal, backendConfig: bc });
@@ -332,7 +332,5 @@ export async function runBackend(
 	} catch (err) {
 		recordBackendFailure(backend);
 		throw err;
-	} finally {
-		markCooldown(backend);
 	}
 }

--- a/extensions/cooldown.test.ts
+++ b/extensions/cooldown.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearCooldowns, waitForCooldown } from "./utils.js";
+
+describe("per-backend cooldown", () => {
+	afterEach(() => {
+		clearCooldowns();
+		vi.useRealTimers();
+	});
+
+	it("serializes parallel reservations using the configured interval", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(10_000);
+
+		const starts: number[] = [];
+		const reserve = async () => {
+			await waitForCooldown("perplexity", 1_500);
+			starts.push(Date.now());
+		};
+
+		const requests = [reserve(), reserve(), reserve()];
+		await vi.runAllTimersAsync();
+		await Promise.all(requests);
+
+		expect(starts).toEqual([10_000, 11_500, 13_000]);
+	});
+
+	it("maintains independent queues for different backends", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(20_000);
+
+		const starts: Array<[string, number]> = [];
+		const reserve = async (backend: string) => {
+			await waitForCooldown(backend, 1_500);
+			starts.push([backend, Date.now()]);
+		};
+
+		await Promise.all([reserve("perplexity"), reserve("tavily")]);
+
+		expect(starts).toEqual([
+			["perplexity", 20_000],
+			["tavily", 20_000],
+		]);
+	});
+
+	it("allows throttling to be disabled with a zero interval", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(30_000);
+
+		const starts: number[] = [];
+		await Promise.all(Array.from({ length: 3 }, async () => {
+			await waitForCooldown("perplexity", 0);
+			starts.push(Date.now());
+		}));
+
+		expect(starts).toEqual([30_000, 30_000, 30_000]);
+	});
+});

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -7,6 +7,8 @@ export interface BackendConfig {
 	apiKey?: string;
 	/** Per-backend timeout override in milliseconds. Default: 30000 */
 	timeout?: number;
+	/** Minimum milliseconds between request starts for this backend. Default: 2000. */
+	requestIntervalMs?: number;
 	/** Per-backend max results override. Default: 10 */
 	maxResults?: number;
 	/** Per-backend extra headers */

--- a/extensions/utils.ts
+++ b/extensions/utils.ts
@@ -33,21 +33,32 @@ export function getAgentDir(): string {
 // ---------------------------------------------------------------------------
 
 const backendCooldowns = new Map<string, number>();
+const backendCooldownQueues = new Map<string, Promise<void>>();
 
-export function waitForCooldown(backend: string): Promise<void> {
-	const until = backendCooldowns.get(backend);
-	if (!until) return Promise.resolve();
-	const delay = until - Date.now();
-	if (delay <= 0) return Promise.resolve();
-	return new Promise(r => setTimeout(r, delay));
-}
-
-export function markCooldown(backend: string) {
-	backendCooldowns.set(backend, Date.now() + COOLDOWN_MS);
+/**
+ * Reserve the next request slot for a backend.
+ *
+ * Reservations are serialized so parallel web_search calls cannot all observe
+ * an expired cooldown and start together. The interval is measured between
+ * request start times, which directly enforces provider TPS limits.
+ */
+export async function waitForCooldown(backend: string, minIntervalMs = COOLDOWN_MS): Promise<void> {
+	const interval = Number.isFinite(minIntervalMs) && minIntervalMs >= 0
+		? minIntervalMs
+		: COOLDOWN_MS;
+	const previous = backendCooldownQueues.get(backend) ?? Promise.resolve();
+	const reservation = previous.catch(() => {}).then(async () => {
+		const delay = (backendCooldowns.get(backend) ?? 0) - Date.now();
+		if (delay > 0) await new Promise<void>(resolve => setTimeout(resolve, delay));
+		backendCooldowns.set(backend, Date.now() + interval);
+	});
+	backendCooldownQueues.set(backend, reservation);
+	await reservation;
 }
 
 export function clearCooldowns() {
 	backendCooldowns.clear();
+	backendCooldownQueues.clear();
 }
 
 // ---------------------------------------------------------------------------

--- a/search.json.example
+++ b/search.json.example
@@ -15,7 +15,7 @@
     "firecrawl": { "enabled": true, "apiKey": "FIRECRAWL_API_KEY" },
     "langsearch": { "enabled": true, "apiKey": "LANGSEARCH_API_KEY" },
     "websearchapi": { "enabled": true, "apiKey": "WEBSEARCHAPI_API_KEY" },
-    "perplexity": { "enabled": true, "apiKey": "PERPLEXITY_API_KEY", "model": "sonar" },
+    "perplexity": { "enabled": true, "apiKey": "PERPLEXITY_API_KEY", "model": "sonar", "requestIntervalMs": 1500 },
     "searxng": { "enabled": true, "instanceUrl": "http://localhost:8888" }
   }
 }


### PR DESCRIPTION
## Summary

- add per-backend `requestIntervalMs` configuration
- serialize request-slot reservations per backend so parallel `web_search` calls cannot bypass the cooldown
- measure the interval between request starts rather than from request completion
- preserve the existing 2000 ms default and allow `0` to disable throttling
- document a Perplexity 1 TPS configuration example

## Why

The existing cooldown does not protect concurrent calls: multiple calls can all inspect an expired cooldown before any call reaches `markCooldown()`. It also starts the cooldown only after a request completes, so it cannot directly enforce a requests-per-second limit.

This was reproducible with real Pi `web_search` calls against a Perplexity account limited to 1 TPS. Ten calls were submitted in one parallel tool-call batch.

Before this change, using a small fixed interval still produced a rate-limit response in a five-call batch:

```text
4 searches succeeded
1 search failed:
Perplexity API error (429): Request rate limit exceeded, please try again later.
```

With this change and:

```json
"perplexity": {
  "requestIntervalMs": 1500
}
```

the live follow-up batch completed as:

```text
10 searches succeeded
0 HTTP 429 errors
0 other errors
```

No API keys or private query data are included here.

## Implementation

Each backend has an independent promise queue. A caller reserves its request start slot after the previous reservation, waits until the backend's next allowed start time, and then advances that time by the configured interval. Different backends remain independent and can run concurrently.

## Tests

Added coverage for:

- concurrent calls spaced by the configured interval
- independent queues for different backends
- disabling throttling with `requestIntervalMs: 0`

```text
Test Files  11 passed (11)
Tests       178 passed (178)
```
