### PR TITLE
Honor showStatus during search and read progress

### DIFF
--- a/extensions/search-hub.ts
+++ b/extensions/search-hub.ts
@@ -19,7 +19,7 @@
  * Config: ~/.pi/agent/extensions/search.json + .pi/search.json (project wins)
  * Credentials: env var refs (ALL_CAPS), shell commands (!command), or literal keys
  *
- * Statusline activity: Shows "search" status during search operations
+ * Statusline activity: Shows search/read progress when showStatus is enabled
  *
  * Example .pi/search.json:
  *   {
@@ -145,7 +145,9 @@ export default function (pi: ExtensionAPI) {
 
 			// Helper to update statusline
 			const setStatus = (status: string) => {
-				ctx.ui.setStatus("search", status);
+				if (config.showStatus !== false) {
+					ctx.ui.setStatus("search", status);
+				}
 				onUpdate?.({ content: [{ type: "text", text: `*${status}*` }] });
 			};
 
@@ -390,7 +392,9 @@ export default function (pi: ExtensionAPI) {
 
 			// Helper to update statusline for web_read
 			const setStatus = (status: string) => {
-				ctx.ui.setStatus("read", status);
+				if (config.showStatus !== false) {
+					ctx.ui.setStatus("read", status);
+				}
 				onUpdate?.({ content: [{ type: "text", text: `*${status}*` }] });
 			};
 
@@ -941,6 +945,9 @@ export default function (pi: ExtensionAPI) {
 		if (config.showStatus !== false) {
 			const status = getActiveBackends().join(", ");
 			ctx.ui.setStatus("search", `search: ${status}`);
+		} else {
+			ctx.ui.setStatus("search", undefined);
+			ctx.ui.setStatus("read", undefined);
 		}
 	});
 }

--- a/types/pi-coding-agent.d.ts
+++ b/types/pi-coding-agent.d.ts
@@ -15,7 +15,7 @@ declare module "@earendil-works/pi-coding-agent" {
 
 	export interface UI {
 		notify(message: string, type?: "info" | "warn" | "error" | "success"): void;
-		setStatus(key: string, status: string): void;
+		setStatus(key: string, status: string | undefined): void;
 		select<T extends string>(label: string, options: T[]): Promise<T | undefined>;
 		select<T extends UISelectOption>(label: string, options: T[]): Promise<T | undefined>;
 		input(label: string, options?: UIInputOptions): Promise<string | undefined>;


### PR DESCRIPTION
## Summary

`showStatus` currently controls the status added when a session starts, but `web_search` and `web_read` keep writing progress to the footer when it is `false`.

This change applies the same setting to runtime progress and clears stale search and read statuses when Pi reloads.

The default is unchanged. Statuses still appear when `showStatus` is omitted or set to `true`; users can opt out with `"showStatus": false`.

## Verification

- Loaded the extension through Pi after switching to the local package
- Reloaded with `showStatus: false`
- Ran a DuckDuckGo search successfully
- Ran `git diff --check`